### PR TITLE
chore(ci): trigger github pages publish on release tags only

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,9 +2,9 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes for release tags
   push:
-    branches: ["main"]
+    tags: ["v*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- update the book deployment workflow to run on release tags matching `v*`
- keep the manual `workflow_dispatch` trigger available for ad-hoc runs

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691764a44224832aa341dd2b13e4b2b8)