### PR TITLE
fix(cli): refresh CLI references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ req --help
 
 Quick start:
 
+Requiem does not require a dedicated initialization command—create a directory (optionally a Git repository) and start adding requirements.
+
 ```sh
-# Initialize a new requirements repository
+# Create a new requirements repository directory
 mkdir my-requirements && cd my-requirements
-req init
+
+# (Optional) create git repository alongside your requirements
+# git init && git commit --allow-empty -m "Start requirements repo"
 
 # Add a couple of user requirements
 req add USR --title "User Login" --body "Users shall be able to log in"
@@ -95,8 +99,11 @@ req add SYS --parent USR-001 --title "Authentication Service"
 # Link an existing requirement to a parent
 req link SYS-001 USR-002
 
+# View repository status at any time
+req status
+
 # Check for suspect links (parent requirements that have changed)
-req check
+req suspect
 
 # Accept and update suspect links after review
 req accept SYS-001 USR-001

--- a/docs/src/advanced/cycles.md
+++ b/docs/src/advanced/cycles.md
@@ -71,7 +71,7 @@ USR-001 → USR-001
 ### Cycle Detection Command
 
 ```bash
-req check-cycles
+req diagnose cycles
 ```
 
 **Output** (if cycles found):
@@ -100,7 +100,7 @@ No cycles detected. Requirement graph is acyclic.
 ### Detailed Cycle Information
 
 ```bash
-req check-cycles --detailed
+req diagnose cycles --detailed
 ```
 
 **Output**:
@@ -126,7 +126,7 @@ Cycle 1:
 Generate cycle diagrams:
 
 ```bash
-req check-cycles --visualize > cycles.dot
+req diagnose cycles --visualize > cycles.dot
 dot -Tpng cycles.dot -o cycles.png
 ```
 
@@ -181,10 +181,10 @@ SYS-002 → USR-001  (creates cycle)
 # .github/workflows/requirements.yml (planned)
 - name: Check for cycles
   run: |
-    req check-cycles
+    req diagnose cycles
     if [ $? -ne 0 ]; then
       echo "Cycles detected!"
-      req check-cycles --detailed
+      req diagnose cycles --detailed
       exit 1
     fi
 ```
@@ -201,7 +201,7 @@ SYS-002 → USR-001  (creates cycle)
 
 ```bash
 # Detect cycles
-req check-cycles --detailed
+req diagnose cycles --detailed
 
 # Output:
 # Cycle 1: USR-001 → SYS-001 → SYS-002 → USR-001
@@ -211,7 +211,7 @@ req check-cycles --detailed
 vim USR-001.md  # Remove SYS-002 from parents
 
 # Verify
-req check-cycles
+req diagnose cycles
 # No cycles detected
 ```
 
@@ -228,7 +228,7 @@ req check-cycles
 req link SWR-001 SYS-005
 
 # Check if cycle created
-req check-cycles
+req diagnose cycles
 
 # If cycle:
 # Error: Cycle detected: SYS-005 → ... → SWR-001 → SYS-005

--- a/docs/src/maintaining/review-workflows.md
+++ b/docs/src/maintaining/review-workflows.md
@@ -35,7 +35,7 @@ Found 3 suspect link(s):
 
 Exit codes:
 - `0`: No suspect links (all current)
-- `1`: Suspect links found (useful for CI/CD)
+- `2`: Suspect links found (useful for CI/CD)
 
 **`req accept <CHILD> <PARENT>`** - Accept a suspect link after review
 
@@ -127,7 +127,7 @@ Requirements will have review states:
 
 ```bash
 # Check for requirements needing review
-req check
+req suspect
 
 # Mark requirement as under review
 req review start SYS-001
@@ -340,10 +340,10 @@ Total      | 148
 Suspect links: 3
 ```
 
-If the command exits with code `1`, use the suspect link total as your release checklist—clear
+If the command exits with code `2`, use the suspect link total as your release checklist—clear
 them before shipping:
 ```bash
-req check
+req suspect
 # Review each flagged requirement
 req review complete ...
 ```
@@ -423,7 +423,7 @@ Reviews tracked alongside code changes:
 vim USR-001.md
 
 # Flag affected requirements
-req check
+req suspect
 
 # Create PR with review tracking
 git checkout -b update-usr-001
@@ -442,7 +442,7 @@ git commit -m "Update USR-001: clarify email validation"
 # .github/workflows/requirements.yml (planned)
 - name: Check review status
   run: |
-    req check
+    req suspect
     if [ $? -ne 0 ]; then
       echo "Requirements need review"
       exit 1
@@ -454,8 +454,8 @@ git commit -m "Update USR-001: clarify email validation"
 Automatically create issues for flagged requirements:
 
 ```bash
-req check --create-issues
-# Creates GitHub/Jira issues for each requirement needing review
+req suspect --format json | ./scripts/create-issues
+# Use the JSON output to open tracking issues for each requirement needing review
 ```
 
 ## Current Workflow Examples


### PR DESCRIPTION
## Summary
- update the README quick start to describe manual setup and the current CLI subcommands
- replace legacy `req check` guidance in the review workflows doc with the modern `req status`/`req suspect` commands and exit codes
- retitle the planned cycle detection command to `req diagnose cycles` throughout the advanced documentation

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178f4cd1ac832ab90be91beb4e54a8)