### PR TITLE
fix: resolve cargo-deny advisories by upgrading rmcp to 2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"
@@ -151,9 +151,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -384,11 +384,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -398,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -491,12 +490,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -877,10 +870,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "petgraph"
@@ -1127,15 +1120,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.9.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa07b85b779d1e1df52dd79f6c6bffbe005b191f07290136cc42a142da3409a"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -1149,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.9.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fa09933cac0d0204c8a5d647f558425538ed6a0134b1ebb1ae4dc00c96db3"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/req-mcp/Cargo.toml
+++ b/req-mcp/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 version = "0.1.1"
 edition = "2024"
 license = "MIT"
-rust-version = "1.85.1"
+rust-version = "1.88.0"
 
 [[bin]]
 name = "req-mcp"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 requirements-manager-core = { path = "../req-core" }
 anyhow = "1.0.98"
-rmcp = { version = "0.9", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "2", features = ["server", "transport-io", "macros"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.138"
 tokio = { version = "1", features = ["full"] }

--- a/req-mcp/src/server.rs
+++ b/req-mcp/src/server.rs
@@ -4,8 +4,8 @@
 use requiem_core::Hrid;
 use rmcp::{
     handler::server::router::tool::ToolRouter,
-    model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
-    tool_handler, ErrorData as McpError, ServerHandler,
+    model::{content::Content, CallToolResult},
+    ErrorData as McpError,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -45,25 +45,22 @@ impl ReqMcpServer {
     }
 
     pub(crate) fn success(summary: impl Into<String>, data: Value) -> CallToolResult {
-        CallToolResult {
-            content: vec![Content::text(summary.into())],
-            structured_content: Some(data),
-            is_error: Some(false),
-            meta: None,
-        }
+        let mut result = CallToolResult::success(vec![Content::text(summary.into())]);
+        result.structured_content = Some(data);
+        result
     }
 
     pub(crate) fn stub(tool: &str, params: Option<Value>) -> CallToolResult {
-        CallToolResult {
-            content: vec![Content::text(format!("{tool} is not implemented yet"))],
-            structured_content: Some(json!({
-                "status": "not_implemented",
-                "tool": tool,
-                "params": params.unwrap_or(Value::Null),
-            })),
-            is_error: Some(true),
-            meta: None,
-        }
+        let mut result = CallToolResult::success(vec![Content::text(format!(
+            "{tool} is not implemented yet"
+        ))]);
+        result.is_error = Some(true);
+        result.structured_content = Some(json!({
+            "status": "not_implemented",
+            "tool": tool,
+            "params": params.unwrap_or(Value::Null),
+        }));
+        result
     }
 
     pub(crate) fn serialize<T: Serialize>(value: T, context: &str) -> Result<Value, McpError> {
@@ -73,27 +70,5 @@ impl ReqMcpServer {
                 Some(json!({ "context": context, "reason": error.to_string() })),
             )
         })
-    }
-}
-
-#[tool_handler]
-impl ServerHandler for ReqMcpServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            instructions: Some(
-                "Requirements graph MCP server (requires REQ_ROOT pointing at your requirements \
-                 repo). Start with list_requirement_kinds, then list_requirements(kind) to get \
-                 HRIDs. Fetch details with get_requirement(hrid) and traverse with \
-                 get_children(hrid), get_parents(hrid), get_ancestors(hrid), or \
-                 get_descendants(hrid). Create new kinds/requirements with \
-                 create_requirement_kind and create_requirement. For link drift, call review to \
-                 list suspect child→parent links (fingerprint mismatches), then \
-                 review_requirement to accept if the child still satisfies the parent. \
-                 Search/update tools remain placeholders for now."
-                    .to_owned(),
-            ),
-            ..ServerInfo::default()
-        }
     }
 }

--- a/req-mcp/src/server.rs
+++ b/req-mcp/src/server.rs
@@ -3,8 +3,7 @@
 
 use requiem_core::Hrid;
 use rmcp::{
-    handler::server::router::tool::ToolRouter,
-    model::{content::Content, CallToolResult},
+    model::{CallToolResult, ContentBlock},
     ErrorData as McpError,
 };
 use serde::Serialize;
@@ -17,18 +16,13 @@ use crate::state::ServerState;
 pub struct ReqMcpServer {
     /// Shared directory and configuration state.
     pub(crate) state: ServerState,
-    /// Generated router containing all exposed tools.
-    pub(crate) tool_router: ToolRouter<Self>,
 }
 
 impl ReqMcpServer {
     /// Create a new server with the provided state.
     #[must_use]
-    pub fn new(state: ServerState) -> Self {
-        Self {
-            state,
-            tool_router: Self::build_tool_router(),
-        }
+    pub const fn new(state: ServerState) -> Self {
+        Self { state }
     }
 
     pub(crate) fn format_hrid(hrid: &Hrid, digits: usize) -> String {
@@ -45,15 +39,14 @@ impl ReqMcpServer {
     }
 
     pub(crate) fn success(summary: impl Into<String>, data: Value) -> CallToolResult {
-        let mut result = CallToolResult::success(vec![Content::text(summary.into())]);
+        let mut result = CallToolResult::success(vec![ContentBlock::text(summary.into())]);
         result.structured_content = Some(data);
         result
     }
 
     pub(crate) fn stub(tool: &str, params: Option<Value>) -> CallToolResult {
-        let mut result = CallToolResult::success(vec![Content::text(format!(
-            "{tool} is not implemented yet"
-        ))]);
+        let message = format!("{tool} is not implemented yet");
+        let mut result = CallToolResult::success(vec![ContentBlock::text(message)]);
         result.is_error = Some(true);
         result.structured_content = Some(json!({
             "status": "not_implemented",

--- a/req-mcp/src/tools.rs
+++ b/req-mcp/src/tools.rs
@@ -225,12 +225,9 @@ impl ReqMcpServer {
     }
 }
 
-impl ReqMcpServer {
-    pub(crate) fn build_tool_router() -> rmcp::handler::server::router::tool::ToolRouter<Self> {
-        Self::tool_router()
-    }
-}
-
+// The `#[tool_handler]` macro expands to `ServerHandler` methods that are async
+// (as required by the trait) but contain no `.await`; allow the resulting lint.
+#[allow(clippy::unused_async_trait_impl)]
 #[tool_handler]
 impl ServerHandler for ReqMcpServer {
     fn get_info(&self) -> ServerInfo {
@@ -241,13 +238,13 @@ impl ServerHandler for ReqMcpServer {
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.instructions = Some(
             "Requirements graph MCP server (requires REQ_ROOT pointing at your requirements \
-             repo). Start with list_requirement_kinds, then list_requirements(kind) to get \
-             HRIDs. Fetch details with get_requirement(hrid) and traverse with \
-             get_children(hrid), get_parents(hrid), get_ancestors(hrid), or \
-             get_descendants(hrid). Create new kinds/requirements with create_requirement_kind \
-             and create_requirement. For link drift, call review to list suspect child→parent \
-             links (fingerprint mismatches), then review_requirement to accept if the child \
-             still satisfies the parent. Search/update tools remain placeholders for now."
+             repo). Start with list_requirement_kinds, then list_requirements(kind) to get HRIDs. \
+             Fetch details with get_requirement(hrid) and traverse with get_children(hrid), \
+             get_parents(hrid), get_ancestors(hrid), or get_descendants(hrid). Create new \
+             kinds/requirements with create_requirement_kind and create_requirement. For link \
+             drift, call review to list suspect child→parent links (fingerprint mismatches), then \
+             review_requirement to accept if the child still satisfies the parent. Search/update \
+             tools remain placeholders for now."
                 .to_owned(),
         );
         info

--- a/req-mcp/src/tools.rs
+++ b/req-mcp/src/tools.rs
@@ -4,8 +4,9 @@ mod lineage;
 mod search;
 
 use rmcp::{
-    handler::server::wrapper::Parameters, model::CallToolResult, tool, tool_router,
-    ErrorData as McpError,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 
 use crate::server::ReqMcpServer;
@@ -227,5 +228,28 @@ impl ReqMcpServer {
 impl ReqMcpServer {
     pub(crate) fn build_tool_router() -> rmcp::handler::server::router::tool::ToolRouter<Self> {
         Self::tool_router()
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ReqMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        // `ServerInfo` is `#[non_exhaustive]`, so it can only be built from its
+        // `Default` and then customised in place.
+        #[allow(clippy::field_reassign_with_default)]
+        let mut info = ServerInfo::default();
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info.instructions = Some(
+            "Requirements graph MCP server (requires REQ_ROOT pointing at your requirements \
+             repo). Start with list_requirement_kinds, then list_requirements(kind) to get \
+             HRIDs. Fetch details with get_requirement(hrid) and traverse with \
+             get_children(hrid), get_parents(hrid), get_ancestors(hrid), or \
+             get_descendants(hrid). Create new kinds/requirements with create_requirement_kind \
+             and create_requirement. For link drift, call review to list suspect child→parent \
+             links (fingerprint mismatches), then review_requirement to accept if the child \
+             still satisfies the parent. Search/update tools remain placeholders for now."
+                .to_owned(),
+        );
+        info
     }
 }


### PR DESCRIPTION
## Summary

The `cargo-deny` CI job was failing on its **advisories** check. Four crates in the dependency tree had open RUSTSEC advisories:

| Advisory | Crate | Resolution |
| --- | --- | --- |
| [RUSTSEC-2026-0189](https://rustsec.org/advisories/RUSTSEC-2026-0189) | `rmcp 0.9.1` | DNS rebinding in the Streamable HTTP server transport → upgrade `rmcp` to `2.1.0` |
| [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) | `paste 1.0.15` | unmaintained (pulled in transitively by `rmcp`) → dropped; `rmcp` 2.x uses `pastey` instead |
| [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) | `crossbeam-epoch 0.9.18` | invalid pointer dereference → bump to `0.9.20` |
| [RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007) | `bytes 1.11.0` | `BytesMut::reserve` overflow → bump to `1.12.0` |
| [RUSTSEC-2026-0006](https://rustsec.org/advisories/RUSTSEC-2026-0006) | `anyhow 1.0.100` | bump to `1.0.103` |

Upgrading `rmcp` to 2.x resolves both the `rmcp` vulnerability and the unmaintained `paste` advisory in one move (no `deny.toml` suppressions were needed).

## Changes

**`chore(deps)`**
- `rmcp` `0.9.1` → `2.1.0`, plus the vulnerable-dependency bumps above.
- `rmcp` 2.x pulls in `darling 0.23`, which requires rustc `1.88`, so **`req-mcp`'s MSRV is raised to `1.88.0`**. `req` and `req-core` are unaffected and keep their `1.85.1` MSRV.

**`refactor(mcp)`** — migrate `req-mcp` to the rmcp 2.x API:
- The content type was renamed `Content` → `ContentBlock`.
- `CallToolResult` and `ServerInfo` are now `#[non_exhaustive]`, so they are built via `CallToolResult::success` / `ServerInfo::default()` and their public fields are set in place rather than with struct literals.
- `#[tool_handler]` now resolves the `#[tool_router]`-generated associated function directly, so the `ServerHandler` impl moved alongside the tool router in `tools.rs`, and the now-redundant cached `tool_router` field was removed.

## Notes
- `req-mcp` only uses the **stdio** transport, so it was never actually exposed to the rmcp HTTP DNS-rebinding vector — the upgrade is still the right fix and clears the advisory.