### PR TITLE
ci: use codecov OIDC for tokenless coverage upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
@@ -73,8 +75,8 @@ jobs:
       - run: cargo llvm-cov --all-features --doctests --workspace --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v5
         with:
+          use_oidc: true
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   example-mdbook:


### PR DESCRIPTION
Switch the coverage job to Codecov's OIDC (OpenID Connect) authentication
instead of a shared upload token. This grants the job id-token: write
permission and sets use_oidc: true on codecov-action, so uploads work on
pull requests (including forks) without relying on the CODECOV_TOKEN secret.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YH6GnRvpFDgo72KsuodUmz