### PR TITLE
fix(ci): use squash merge for Dependabot auto-merge action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Dependabot auto-merge used a merge-commit strategy which can fail on repositories configured to allow only squash merges, so the workflow needs to use the squash strategy.

### Description
- Replace the auto-merge command in `.github/workflows/CI.yml` to use `gh pr merge --auto --squash "$PR_URL"` instead of the previous `--merge` flag.

### Testing
- Ran `git diff --check` (passed) and `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/CI.yml")'` (passed), committed the workflow change, and a Python `yaml.safe_load` check failed in the environment due to a missing `PyYAML` module but the YAML itself is unchanged and valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd73d2fd0832ab6cef242de74d990)