### PR TITLE
fix: harden storage durability and correct CLI/domain defects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Workspace layout:
 
 - `req-core`: domain and storage library (HRIDs, Directory, fingerprinting)
 - `req`: CLI binary (`req`)
-- `req-mcp`: Model Context Protocol server (read-only MVP; editing tools stubbed)
+- `req-mcp`: Model Context Protocol server (discovery, lineage, and editing tools)
 - `docs/`: mdBook docs and the project's own requirements (`docs/src/requirements/`)
 
 Naming note:

--- a/req-core/Cargo.toml
+++ b/req-core/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "1.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
+tempfile = "3.20.0"
 thiserror = "2.0.12"
 toml = "0.9.2"
 tracing = "0.1.41"
@@ -33,7 +34,6 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 criterion = "0.8.2"
-tempfile = "3.20.0"
 test-case = "3.3.1"
 
 [lints]

--- a/req-core/Cargo.toml
+++ b/req-core/Cargo.toml
@@ -30,7 +30,6 @@ toml = "0.9.2"
 tracing = "0.1.41"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 walkdir = "2.5.0"
-regex = "1.11.1"
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/req-core/src/domain/config.rs
+++ b/req-core/src/domain/config.rs
@@ -95,6 +95,22 @@ impl Config {
         let mut tmp = tempfile::NamedTempFile::new_in(dir).map_err(|e| write_err(&e))?;
         tmp.write_all(content.as_bytes())
             .map_err(|e| write_err(&e))?;
+
+        // The temp file is created owner-only on Unix and persist replaces
+        // the destination inode; carry over the destination's existing
+        // permissions (or the conventional 0o644 for new files).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = std::fs::metadata(path).map_or_else(
+                |_| std::fs::Permissions::from_mode(0o644),
+                |metadata| metadata.permissions(),
+            );
+            tmp.as_file()
+                .set_permissions(permissions)
+                .map_err(|e| write_err(&e))?;
+        }
+
         tmp.persist(path).map_err(|e| write_err(&e))?;
         Ok(())
     }

--- a/req-core/src/domain/config.rs
+++ b/req-core/src/domain/config.rs
@@ -80,9 +80,23 @@ impl Config {
     /// Returns an error if the configuration cannot be serialized to TOML or if
     /// the file cannot be written.
     pub fn save(&self, path: &Path) -> Result<(), String> {
+        use std::io::Write as _;
+
         let content =
             toml::to_string_pretty(self).map_err(|e| format!("Failed to serialize config: {e}"))?;
-        std::fs::write(path, content).map_err(|e| format!("Failed to write config file: {e}"))
+
+        // Write to a temporary file in the same directory, then rename it over
+        // the destination so a crash mid-write cannot truncate the config.
+        let dir = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let write_err = |e: &dyn std::fmt::Display| format!("Failed to write config file: {e}");
+        let mut tmp = tempfile::NamedTempFile::new_in(dir).map_err(|e| write_err(&e))?;
+        tmp.write_all(content.as_bytes())
+            .map_err(|e| write_err(&e))?;
+        tmp.persist(path).map_err(|e| write_err(&e))?;
+        Ok(())
     }
 
     /// Returns the number of digits for padding HRID IDs.
@@ -363,6 +377,27 @@ mod tests {
 
         let error = Config::load(file.path()).unwrap_err();
         assert!(error.starts_with("Failed to parse config file:"));
+    }
+
+    #[test]
+    fn save_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let mut config = Config::default();
+        config.add_kind("USR");
+        config.subfolders_are_namespaces = true;
+        config.save(&path).unwrap();
+
+        let loaded = Config::load(&path).unwrap();
+        assert_eq!(loaded, config);
+
+        // The atomic write must not leave temporary files behind.
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("config.toml")]);
     }
 
     #[test]

--- a/req-core/src/domain/config.rs
+++ b/req-core/src/domain/config.rs
@@ -255,14 +255,18 @@ impl From<Versions> for super::Config {
                 allow_invalid: _, // Ignored for backward compatibility
                 subfolders_are_namespaces,
             } => Self {
+                // Normalize kinds to uppercase on load: HRID kinds are always
+                // uppercase and is_kind_allowed compares exactly, so a
+                // lowercase entry in config.toml would silently reject every
+                // requirement of that kind.
                 allowed_kinds: allowed_kinds
                     .iter()
-                    .map(AllowedKindEntry::kind)
-                    .map(ToString::to_string)
+                    .map(|entry| entry.kind().to_uppercase())
                     .collect(),
                 kind_metadata: allowed_kinds
                     .into_iter()
                     .filter_map(AllowedKindEntry::into_metadata)
+                    .map(|(kind, meta)| (kind.to_uppercase(), meta))
                     .collect(),
                 digits,
                 allow_unrecognised,
@@ -377,6 +381,29 @@ mod tests {
 
         let error = Config::load(file.path()).unwrap_err();
         assert!(error.starts_with("Failed to parse config file:"));
+    }
+
+    #[test]
+    fn load_normalizes_kind_case() {
+        let config: Config = toml::from_str(
+            r#"_version = "1"
+allowed_kinds = ["usr", { kind = "sys", description = "System" }]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.allowed_kinds(),
+            &["USR".to_string(), "SYS".to_string()]
+        );
+        assert!(config.is_kind_allowed("USR"));
+        assert_eq!(
+            config
+                .kind_metadata()
+                .get("SYS")
+                .and_then(|meta| meta.description.as_deref()),
+            Some("System")
+        );
     }
 
     #[test]

--- a/req-core/src/domain/hrid.rs
+++ b/req-core/src/domain/hrid.rs
@@ -201,6 +201,39 @@ impl Hrid {
         }
     }
 
+    /// Parses an HRID, normalizing the KIND segment to uppercase.
+    ///
+    /// This is a convenience for user-facing boundaries (CLI arguments, tool
+    /// parameters): `auth-sys-001` parses as `auth-SYS-001`. Namespace case
+    /// is preserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a valid HRID.
+    pub fn parse_lenient(s: &str) -> Result<Self, Error> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() < 2 {
+            return Err(Error::Syntax(s.to_string()));
+        }
+
+        // Uppercase only the KIND segment (second-to-last position).
+        let kind_index = parts.len() - 2;
+        let normalized = parts
+            .iter()
+            .enumerate()
+            .map(|(i, part)| {
+                if i == kind_index {
+                    part.to_uppercase()
+                } else {
+                    (*part).to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("-");
+
+        normalized.parse()
+    }
+
     /// Returns the namespace segments as strings.
     pub fn namespace(&self) -> Vec<&str> {
         self.namespace
@@ -414,6 +447,31 @@ mod tests {
     #[test]
     fn hrid_creation_zero_id_fails() {
         assert!(NonZeroUsize::new(0).is_none());
+    }
+
+    #[test]
+    fn parse_lenient_normalizes_kind_only() {
+        // The KIND segment is normalized to uppercase; namespaces keep their
+        // case; already-uppercase input is untouched.
+        for (input, expected) in [
+            ("SYSTEM-AUTH-REQ-001", "SYSTEM-AUTH-REQ-001"),
+            ("auth-sys-001", "auth-SYS-001"),
+            ("auth-SyS-001", "auth-SYS-001"),
+            ("auth-api-SYS-001", "auth-api-SYS-001"),
+            ("Auth-Api-SYS-001", "Auth-Api-SYS-001"),
+            ("req-001", "REQ-001"),
+            ("a-b-c-d-SYS-001", "a-b-c-d-SYS-001"),
+        ] {
+            let hrid = Hrid::parse_lenient(input).unwrap();
+            assert_eq!(hrid.display(3).to_string(), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn parse_lenient_rejects_invalid_input() {
+        for input in ["invalid", "auth-SYS-invalid", "auth-SYS-000", ""] {
+            assert!(Hrid::parse_lenient(input).is_err(), "input: {input}");
+        }
     }
 
     use test_case::test_case;

--- a/req-core/src/domain/tree.rs
+++ b/req-core/src/domain/tree.rs
@@ -1091,8 +1091,7 @@ impl Tree {
             return false;
         }
         a.is_empty()
-            || (0..b.len())
-                .any(|offset| (0..a.len()).all(|i| a[i] == b[(offset + i) % b.len()]))
+            || (0..b.len()).any(|offset| (0..a.len()).all(|i| a[i] == b[(offset + i) % b.len()]))
     }
 
     /// Check if adding a link from child to parent would create a cycle.

--- a/req-core/src/domain/tree.rs
+++ b/req-core/src/domain/tree.rs
@@ -305,25 +305,10 @@ impl Tree {
     /// intermediate view.
     #[must_use]
     pub fn get_requirement(&self, uuid: Uuid) -> Option<Requirement> {
-        use std::collections::HashMap;
-
         let data = self.requirements.get(&uuid)?;
         let hrid = self.hrids.get(&uuid)?;
 
-        // Reconstruct parents from graph edges
-        let parents: HashMap<Uuid, Parent> = self
-            .graph
-            .edges(uuid)
-            .map(|(_, parent_uuid, edge_data)| {
-                (
-                    parent_uuid,
-                    Parent {
-                        hrid: edge_data.parent_hrid.clone(),
-                        fingerprint: edge_data.fingerprint.clone(),
-                    },
-                )
-            })
-            .collect();
+        let parents = self.parent_links(uuid).into_iter().collect();
 
         Some(Requirement {
             content: crate::domain::requirement::Content {
@@ -350,28 +335,8 @@ impl Tree {
         let data = self.requirements.get(&uuid)?;
         let hrid = self.hrids.get(&uuid)?;
 
-        // Reconstruct parent data from graph edges
-        // Since RequirementView owns the parent data, we can collect directly into Vec
-        let parents: Vec<(Uuid, Parent)> = self
-            .graph
-            .edges(uuid)
-            .map(|(_, parent_uuid, edge_data)| {
-                (
-                    parent_uuid,
-                    Parent {
-                        hrid: edge_data.parent_hrid.clone(),
-                        fingerprint: edge_data.fingerprint.clone(),
-                    },
-                )
-            })
-            .collect();
-
-        // Reconstruct children by finding incoming edges (edges point child→parent)
-        let children: Vec<Uuid> = self
-            .graph
-            .edges_directed(uuid, petgraph::Direction::Incoming)
-            .map(|(child_uuid, _, _)| child_uuid)
-            .collect();
+        let parents = self.parent_links(uuid);
+        let children = self.child_uuids(uuid);
 
         // Get a reference to the UUID from the requirements HashMap key
         // This is safe because we know it exists (we just got data from it)
@@ -398,8 +363,7 @@ impl Tree {
     ///
     /// # Panics
     ///
-    /// Panics if the provided kind is invalid (empty or contains non-alphabetic
-    /// characters).
+    /// Panics if the next requirement ID would overflow `usize`.
     #[must_use]
     pub fn next_index(&self, namespace: &[NamespaceSegment], kind: &KindString) -> NonZeroUsize {
         // Construct range bounds for this namespace+kind combination
@@ -430,26 +394,6 @@ impl Tree {
         self.requirements.iter().filter_map(move |(uuid, data)| {
             let hrid = self.hrids.get(uuid)?;
 
-            let parents: Vec<(Uuid, Parent)> = self
-                .graph
-                .edges(*uuid)
-                .map(|(_, parent_uuid, edge_data)| {
-                    (
-                        parent_uuid,
-                        Parent {
-                            hrid: edge_data.parent_hrid.clone(),
-                            fingerprint: edge_data.fingerprint.clone(),
-                        },
-                    )
-                })
-                .collect();
-
-            let children: Vec<Uuid> = self
-                .graph
-                .edges_directed(*uuid, petgraph::Direction::Incoming)
-                .map(|(child_uuid, _, _)| child_uuid)
-                .collect();
-
             Some(RequirementView {
                 uuid,
                 hrid,
@@ -457,10 +401,34 @@ impl Tree {
                 title: &data.title,
                 body: &data.body,
                 tags: &data.tags,
-                parents,
-                children,
+                parents: self.parent_links(*uuid),
+                children: self.child_uuids(*uuid),
             })
         })
+    }
+
+    /// Collect the parent links of a node from its outgoing graph edges.
+    fn parent_links(&self, uuid: Uuid) -> Vec<(Uuid, Parent)> {
+        self.graph
+            .edges(uuid)
+            .map(|(_, parent_uuid, edge_data)| {
+                (
+                    parent_uuid,
+                    Parent {
+                        hrid: edge_data.parent_hrid.clone(),
+                        fingerprint: edge_data.fingerprint.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Collect the children of a node from its incoming graph edges.
+    fn child_uuids(&self, uuid: Uuid) -> Vec<Uuid> {
+        self.graph
+            .edges_directed(uuid, petgraph::Direction::Incoming)
+            .map(|(child_uuid, _, _)| child_uuid)
+            .collect()
     }
 
     /// Finds a requirement by its human-readable identifier.
@@ -468,12 +436,6 @@ impl Tree {
     pub fn find_by_hrid(&self, hrid: &Hrid) -> Option<RequirementView<'_>> {
         let uuid = self.hrid_to_uuid.get(hrid)?;
         self.requirement(*uuid)
-    }
-
-    /// Finds a requirement by its UUID.
-    #[must_use]
-    pub fn find_by_uuid(&self, uuid: Uuid) -> Option<RequirementView<'_>> {
-        self.requirement(uuid)
     }
 
     /// Remove a requirement from the tree.
@@ -540,10 +502,7 @@ impl Tree {
         self.check_would_create_cycle(child_uuid, parent_uuid)
             .map_err(|e| LinkRequirementError::WouldCreateCycle(e.to_string()))?;
 
-        let already_linked = self
-            .parents(child_uuid)
-            .into_iter()
-            .any(|(uuid, _)| uuid == parent_uuid);
+        let already_linked = self.graph.contains_edge(child_uuid, parent_uuid);
 
         self.upsert_parent_link(child_uuid, parent_uuid, parent_fingerprint)
             .map_err(|error| match error {
@@ -761,10 +720,8 @@ impl Tree {
     ///
     /// Returns an iterator of child UUIDs that were updated.
     ///
-    /// # Panics
-    ///
-    /// Panics if a requirement references a parent UUID that doesn't exist in
-    /// the tree, or if a requirement is its own parent.
+    /// Edges whose parent is missing from the tree (e.g. failed to load) are
+    /// skipped with a warning.
     #[instrument(skip(self))]
     pub fn update_hrids(&mut self) -> impl Iterator<Item = Uuid> + '_ {
         use std::collections::HashSet;
@@ -880,9 +837,8 @@ impl Tree {
     /// A link is suspect when the fingerprint stored in the edge data
     /// does not match the current fingerprint of the parent requirement.
     ///
-    /// # Panics
-    ///
-    /// Panics if a child UUID in the graph doesn't have a corresponding HRID.
+    /// Graph nodes without a corresponding HRID (e.g. failed to load) are
+    /// skipped.
     #[must_use]
     pub fn suspect_links(&self) -> Vec<SuspectLink> {
         use crate::domain::requirement::ContentRef;
@@ -942,21 +898,28 @@ impl Tree {
         child_uuid: Uuid,
         parent_uuid: Uuid,
     ) -> Result<bool, AcceptLinkError> {
+        use crate::domain::requirement::ContentRef;
+
         // Check if child exists in graph
         if !self.graph.contains_node(child_uuid) {
             return Err(AcceptLinkError::ChildNotFound(child_uuid));
         }
 
-        // Check if parent exists and get its fingerprint
-        let parent = self
-            .requirement(parent_uuid)
+        // Compute the parent's current fingerprint directly from its stored
+        // data; building a full RequirementView here would clone every parent
+        // and child link just to hash the content.
+        let current_fingerprint = self
+            .requirements
+            .get(&parent_uuid)
+            .map(|data| {
+                ContentRef {
+                    title: &data.title,
+                    body: &data.body,
+                    tags: &data.tags,
+                }
+                .fingerprint()
+            })
             .ok_or(AcceptLinkError::ParentNotFound(parent_uuid))?;
-        let current_fingerprint = parent.fingerprint();
-
-        // Check if parent exists in graph
-        if !self.graph.contains_node(parent_uuid) {
-            return Err(AcceptLinkError::ParentNotFound(parent_uuid));
-        }
 
         // Find and update the edge
         if let Some(edge_data) = self.graph.edge_weight_mut(child_uuid, parent_uuid) {
@@ -1035,32 +998,50 @@ impl Tree {
         // Start DFS from each unvisited node to ensure we find all cycles
         for start_node in self.graph.nodes() {
             if !colors.contains_key(&start_node) {
-                self.dfs_detect_cycles(start_node, &mut colors, &mut Vec::new(), &mut cycles);
+                self.dfs_detect_cycles(start_node, &mut colors, &mut cycles);
             }
         }
 
         cycles
     }
 
-    /// Recursive helper for three-color DFS cycle detection.
+    /// Iterative helper for three-color DFS cycle detection.
     ///
-    /// Maintains the recursion path to extract full cycle information when back
-    /// edges (edges to Gray nodes) are encountered.
+    /// Each stack frame holds a node, its outgoing neighbours, and the index
+    /// of the next neighbour to visit, so deep parent chains cannot overflow
+    /// the call stack. The current DFS path is maintained to extract full
+    /// cycle information when back edges (edges to Gray nodes) are found.
     fn dfs_detect_cycles(
         &self,
-        node: Uuid,
+        start: Uuid,
         colors: &mut std::collections::HashMap<Uuid, DfsColorForDetection>,
-        path: &mut Vec<Uuid>,
         cycles: &mut Vec<Vec<Hrid>>,
     ) {
         use self::DfsColorForDetection::{Black, Gray};
 
-        // Mark node Gray (entering DFS)
-        colors.insert(node, Gray);
-        path.push(node);
+        let neighbours_of =
+            |node: Uuid| -> Vec<Uuid> { self.graph.edges(node).map(|(_, p, _)| p).collect() };
 
-        // Visit all outgoing edges (children in the parent relation)
-        for (_, parent_uuid, _) in self.graph.edges(node) {
+        let mut path: Vec<Uuid> = Vec::new();
+        let mut stack: Vec<(Uuid, Vec<Uuid>, usize)> = Vec::new();
+
+        colors.insert(start, Gray);
+        path.push(start);
+        stack.push((start, neighbours_of(start), 0));
+
+        while let Some(frame) = stack.last_mut() {
+            let node = frame.0;
+            let next = frame.1.get(frame.2).copied();
+            frame.2 += 1;
+
+            let Some(parent_uuid) = next else {
+                // All outgoing edges visited: mark Black and leave the node.
+                colors.insert(node, Black);
+                path.pop();
+                stack.pop();
+                continue;
+            };
+
             match colors.get(&parent_uuid) {
                 Some(Gray) => {
                     // Back edge found! This node is an ancestor in the current path.
@@ -1071,11 +1052,10 @@ impl Tree {
                             .chain(std::iter::once(&parent_uuid))
                             .filter_map(|&uuid| self.hrids.get(&uuid).cloned())
                             .collect();
-                        if !cycle_path.is_empty() {
-                            // Avoid duplicate cycles by checking if we've already found this one
-                            if !cycles.iter().any(|c| Self::cycles_equal(c, &cycle_path)) {
-                                cycles.push(cycle_path);
-                            }
+                        if !cycle_path.is_empty()
+                            && !cycles.iter().any(|c| Self::cycles_equal(c, &cycle_path))
+                        {
+                            cycles.push(cycle_path);
                         }
                     }
                 }
@@ -1083,37 +1063,36 @@ impl Tree {
                     // Already processed this subtree, skip (cross edge)
                 }
                 None => {
-                    // Unvisited node, recurse
-                    self.dfs_detect_cycles(parent_uuid, colors, path, cycles);
+                    // Unvisited node, descend
+                    colors.insert(parent_uuid, Gray);
+                    path.push(parent_uuid);
+                    stack.push((parent_uuid, neighbours_of(parent_uuid), 0));
                 }
             }
         }
-
-        // Mark node Black (leaving DFS, all descendants processed)
-        colors.insert(node, Black);
-        path.pop();
     }
 
     /// Check if two cycles are equivalent (same HRIDs, possibly rotated).
+    ///
+    /// Cycle paths are closed walks (`[A, B, C, A]`): the comparison drops the
+    /// closing element that repeats the start, then tests whether one sequence
+    /// is a rotation of the other.
     fn cycles_equal(a: &[Hrid], b: &[Hrid]) -> bool {
+        fn open(cycle: &[Hrid]) -> &[Hrid] {
+            match cycle {
+                [rest @ .., last] if rest.first() == Some(last) => rest,
+                _ => cycle,
+            }
+        }
+
+        let a = open(a);
+        let b = open(b);
         if a.len() != b.len() {
             return false;
         }
-        if a.is_empty() {
-            return true;
-        }
-        // Check if b is a rotation of a
-        let b_str = b
-            .iter()
-            .map(|h| h.display(3).to_string())
-            .collect::<Vec<_>>();
-        let doubled = format!("{}{}", b_str.join(","), b_str.join(","));
-        let a_str = a
-            .iter()
-            .map(|h| h.display(3).to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        doubled.contains(&a_str)
+        a.is_empty()
+            || (0..b.len())
+                .any(|offset| (0..a.len()).all(|i| a[i] == b[(offset + i) % b.len()]))
     }
 
     /// Check if adding a link from child to parent would create a cycle.
@@ -1486,5 +1465,59 @@ mod tests {
             result.is_err(),
             "Should detect that D→A would create cycle (A→B→C→D→A)"
         );
+    }
+
+    #[test]
+    fn cycles_equal_detects_wrapped_rotations() {
+        fn cycle(ids: &[&str]) -> Vec<Hrid> {
+            ids.iter().map(|s| s.parse().unwrap()).collect()
+        }
+
+        // The same cycle recorded from different entry points: rotations that
+        // wrap around the start must compare equal.
+        let from_a = cycle(&["USR-001", "USR-002", "USR-003", "USR-001"]);
+        let from_b = cycle(&["USR-002", "USR-003", "USR-001", "USR-002"]);
+        let from_c = cycle(&["USR-003", "USR-001", "USR-002", "USR-003"]);
+        assert!(Tree::cycles_equal(&from_a, &from_b));
+        assert!(Tree::cycles_equal(&from_a, &from_c));
+
+        // Same length and membership but opposite direction: not equal.
+        let reversed = cycle(&["USR-001", "USR-003", "USR-002", "USR-001"]);
+        assert!(!Tree::cycles_equal(&from_a, &reversed));
+
+        // Self-loops.
+        assert!(Tree::cycles_equal(
+            &cycle(&["USR-001", "USR-001"]),
+            &cycle(&["USR-001", "USR-001"])
+        ));
+        assert!(!Tree::cycles_equal(
+            &cycle(&["USR-001", "USR-001"]),
+            &cycle(&["USR-002", "USR-002"])
+        ));
+    }
+
+    #[test]
+    fn detect_cycles_survives_deep_chains() {
+        // A linear parent chain deep enough to overflow the call stack if
+        // cycle detection were recursive.
+        const DEPTH: usize = 20_000;
+
+        let mut tree = Tree::default();
+        let mut uuids = Vec::with_capacity(DEPTH);
+        for i in 1..=DEPTH {
+            let req = Requirement::new(
+                format!("USR-{i}").parse().unwrap(),
+                String::new(),
+                String::new(),
+            );
+            uuids.push(req.uuid());
+            tree.insert(req).unwrap();
+        }
+        for pair in uuids.windows(2) {
+            tree.upsert_parent_link(pair[0], pair[1], "fp".to_string())
+                .unwrap();
+        }
+
+        assert!(tree.detect_cycles().is_empty());
     }
 }

--- a/req-core/src/storage/directory.rs
+++ b/req-core/src/storage/directory.rs
@@ -108,8 +108,8 @@ impl Directory {
     /// Returns an error if unrecognised files are found when
     /// `allow_unrecognised` is false in the configuration.
     pub fn new(root: PathBuf) -> Result<Self, DirectoryLoadError> {
-        let config = load_config(&root);
-        let md_paths = collect_markdown_paths(&root);
+        let config = load_config(&root)?;
+        let md_paths = collect_markdown_paths(&root)?;
 
         let (requirements, unrecognised_paths): (Vec<_>, Vec<_>) = md_paths
             .par_iter()
@@ -192,6 +192,17 @@ pub enum DirectoryLoadError {
         /// The list of allowed kinds
         allowed_kinds: Vec<String>,
     },
+
+    /// The `.req/config.toml` file exists but could not be read or parsed.
+    InvalidConfig {
+        /// The path of the config file.
+        path: PathBuf,
+        /// A description of the failure.
+        message: String,
+    },
+
+    /// The requirements directory could not be traversed.
+    Walk(#[from] walkdir::Error),
 }
 
 impl fmt::Display for DirectoryLoadError {
@@ -229,16 +240,29 @@ impl fmt::Display for DirectoryLoadError {
                 }
                 Ok(())
             }
+            Self::InvalidConfig { path, message } => {
+                write!(f, "Failed to load config {}: {}", path.display(), message)
+            }
+            Self::Walk(error) => {
+                write!(f, "Failed to traverse requirements directory: {error}")
+            }
         }
     }
 }
 
-fn load_config(root: &Path) -> Config {
+/// Load `.req/config.toml` from the root, if present.
+///
+/// A missing config file is the normal un-initialised case and yields the
+/// default configuration. A config file that exists but cannot be read or
+/// parsed is an error: silently falling back to defaults would flip settings
+/// such as `subfolders_are_namespaces` and reinterpret the whole store.
+fn load_config(root: &Path) -> Result<Config, DirectoryLoadError> {
     let path = root.join(".req/config.toml");
-    Config::load(&path).unwrap_or_else(|e| {
-        tracing::debug!("Failed to load config: {e}");
-        Config::default()
-    })
+    if path.exists() {
+        Config::load(&path).map_err(|message| DirectoryLoadError::InvalidConfig { path, message })
+    } else {
+        Ok(Config::default())
+    }
 }
 
 /// Load a template for the given HRID from the `.req/templates/` directory.
@@ -282,17 +306,27 @@ fn load_template(root: &Path, hrid: &Hrid) -> String {
     String::new()
 }
 
-fn collect_markdown_paths(root: &PathBuf) -> Vec<PathBuf> {
-    WalkDir::new(root)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|entry| {
-            // Skip the .req directory (used for templates and other metadata)
-            !entry.path().components().any(|c| c.as_os_str() == ".req")
-        })
-        .filter(|entry| entry.path().extension() == Some(OsStr::new("md")))
-        .map(walkdir::DirEntry::into_path)
-        .collect()
+fn collect_markdown_paths(root: &PathBuf) -> Result<Vec<PathBuf>, DirectoryLoadError> {
+    // A root that doesn't exist yet is an empty store, not an error.
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut paths = Vec::new();
+    for entry in WalkDir::new(root) {
+        // Traversal errors (unreadable directories, dangling links) must
+        // surface: silently skipping them would make requirements vanish.
+        let entry = entry?;
+
+        // Skip the .req directory (used for templates and other metadata)
+        if entry.path().components().any(|c| c.as_os_str() == ".req") {
+            continue;
+        }
+        if entry.path().extension() == Some(OsStr::new("md")) {
+            paths.push(entry.into_path());
+        }
+    }
+    Ok(paths)
 }
 
 fn try_load_requirement(
@@ -1299,7 +1333,7 @@ mod tests {
             .unwrap();
         reloaded.flush().unwrap();
 
-        let config = load_config(&dir.root);
+        let config = load_config(&dir.root).unwrap();
         let updated =
             Requirement::load(&dir.root, child.hrid(), &config).expect("should load child");
 
@@ -1691,6 +1725,51 @@ created: 2025-01-01T00:00:00Z
 
         // Verify both can be flushed without error
         assert!(dir.flush().is_ok());
+    }
+
+    #[test]
+    fn new_fails_on_malformed_config() {
+        let tmp = TempDir::new().unwrap();
+        let req_dir = tmp.path().join(".req");
+        std::fs::create_dir_all(&req_dir).unwrap();
+        std::fs::write(req_dir.join("config.toml"), "not valid toml [[[").unwrap();
+
+        let result = Directory::new(tmp.path().to_path_buf());
+        assert!(matches!(
+            result,
+            Err(DirectoryLoadError::InvalidConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn new_defaults_when_config_missing() {
+        let (_tmp, dir) = setup_temp_directory();
+        assert_eq!(dir.config, Config::default());
+    }
+
+    #[test]
+    fn new_on_nonexistent_root_is_empty_store() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("does-not-exist");
+        let dir = Directory::new(root).unwrap();
+        assert_eq!(dir.requirements().count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_reports_unreadable_subdirectory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("locked");
+        std::fs::create_dir(&sub).unwrap();
+        let original_perms = std::fs::metadata(&sub).unwrap().permissions();
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = Directory::new(tmp.path().to_path_buf());
+
+        std::fs::set_permissions(&sub, original_perms).unwrap();
+        assert!(matches!(result, Err(DirectoryLoadError::Walk(_))));
     }
 
     #[test]

--- a/req-core/src/storage/directory.rs
+++ b/req-core/src/storage/directory.rs
@@ -36,8 +36,9 @@ pub struct Directory {
     /// Source paths for requirements that were loaded from disk.
     /// Used to save requirements back to their original location.
     paths: HashMap<Uuid, PathBuf>,
-    /// Paths to delete on flush.
-    deletions: HashSet<PathBuf>,
+    /// Paths to delete on flush, keyed by the UUID of the requirement whose
+    /// deletion, rename, or move queued them.
+    deletions: HashMap<PathBuf, Uuid>,
 }
 
 impl Directory {
@@ -164,7 +165,7 @@ impl Directory {
             config,
             dirty: HashSet::new(),
             paths,
-            deletions: HashSet::new(),
+            deletions: HashMap::new(),
         })
     }
 }
@@ -476,7 +477,7 @@ impl Directory {
 
         // Mark file for deletion
         if let Some(path) = self.paths.remove(&uuid) {
-            self.deletions.insert(path);
+            self.deletions.insert(path, uuid);
         }
 
         Ok(())
@@ -515,7 +516,7 @@ impl Directory {
 
         // Mark file for deletion
         if let Some(path) = self.paths.remove(&uuid) {
-            self.deletions.insert(path);
+            self.deletions.insert(path, uuid);
         }
 
         Ok(())
@@ -609,15 +610,14 @@ impl Directory {
         // Perform rename in tree (this updates all parent references)
         let (uuid, children_uuids) = self.tree.rename_requirement(old_hrid, new_hrid)?;
 
-        // Update file path mapping
+        // Update file path mapping. The new path is registered even when no
+        // old path was recorded (e.g. a requirement added and renamed before
+        // ever being flushed) so the old file is always reconciled on flush.
         if let Some(old_path) = self.paths.remove(&uuid) {
-            // Mark old file for deletion
-            self.deletions.insert(old_path);
-
-            // Calculate new path
-            let new_path = self.canonical_path_for(new_hrid);
-            self.paths.insert(uuid, new_path);
+            self.deletions.insert(old_path, uuid);
         }
+        let new_path = self.canonical_path_for(new_hrid);
+        self.paths.insert(uuid, new_path);
 
         // Mark the renamed requirement as dirty
         self.dirty.insert(uuid);
@@ -694,7 +694,7 @@ impl Directory {
         // Update file path mapping
         if let Some(old_path) = self.paths.remove(&uuid) {
             // Mark old file for deletion
-            self.deletions.insert(old_path);
+            self.deletions.insert(old_path, uuid);
         }
 
         // Set new path
@@ -815,6 +815,8 @@ impl Directory {
         let requirement = Requirement::new(hrid, title, body);
 
         tree.insert(requirement.clone())?;
+        let canonical = self.canonical_path_for(requirement.hrid());
+        self.paths.insert(requirement.uuid(), canonical);
         self.mark_dirty(requirement.uuid());
 
         tracing::info!(
@@ -1062,59 +1064,76 @@ impl Directory {
     /// Returns an error containing the paths that failed to flush alongside the
     /// underlying IO error.
     pub fn flush(&mut self) -> Result<Vec<Hrid>, FlushError> {
-        use crate::storage::path_parser::construct_path_from_hrid;
-
-        let dirty: Vec<_> = self.dirty.iter().copied().collect();
+        let digits = self.config.digits();
+        let mut failures: Vec<(PathBuf, io::Error)> = Vec::new();
         let mut flushed = Vec::new();
-        let mut failures = Vec::new();
 
+        // Phase 1: resolve write targets. Computed fallback paths are recorded
+        // in `self.paths` so a later rename can find (and queue for deletion)
+        // the file this flush is about to create.
+        let dirty: Vec<_> = self.dirty.iter().copied().collect();
+        let mut writes: Vec<(Uuid, Requirement, PathBuf)> = Vec::new();
         for uuid in dirty {
             let Some(requirement) = self.tree.get_requirement(uuid) else {
-                // Requirement may have been removed; drop from dirty set.
+                // Requirement was removed since being marked dirty.
                 self.dirty.remove(&uuid);
                 continue;
             };
+            let canonical = self.canonical_path_for(requirement.hrid());
+            let path = self.paths.entry(uuid).or_insert(canonical).clone();
+            writes.push((uuid, requirement, path));
+        }
+        // Deterministic write order (and hence deterministic flushed output).
+        writes.sort_by(|a, b| a.2.cmp(&b.2));
 
-            let hrid = requirement.hrid().clone();
-
-            // Use the stored path if available, otherwise calculate a canonical path
-            let path = self.paths.get(&uuid).map_or_else(
-                || {
-                    construct_path_from_hrid(
-                        &self.root,
-                        &hrid,
-                        self.config.subfolders_are_namespaces,
-                        self.config.digits(),
-                    )
-                },
-                PathBuf::clone,
-            );
-
-            match requirement.save_to_path(&path, self.config.digits()) {
+        // Phase 2: perform all writes (each atomic). A failure must not abort
+        // the flush: skipping the deletion phase after a rename would leave
+        // two files with the same UUID and wedge the next load.
+        let mut failed_writes: HashSet<Uuid> = HashSet::new();
+        for (uuid, requirement, path) in &writes {
+            match requirement.save_to_path(path, digits) {
                 Ok(()) => {
-                    self.dirty.remove(&uuid);
-                    flushed.push(hrid);
+                    self.dirty.remove(uuid);
+                    flushed.push(requirement.hrid().clone());
                 }
                 Err(err) => {
-                    failures.push((path, err));
+                    failed_writes.insert(*uuid);
+                    failures.push((path.clone(), err));
                 }
             }
         }
+
+        // Phase 3: reconcile and process deletions.
+        let live_paths: HashSet<&PathBuf> = self.paths.values().collect();
+        let mut deferred: HashMap<PathBuf, Uuid> = HashMap::new();
+        for (path, owner) in self.deletions.drain() {
+            // The path was re-claimed as the live location of some requirement
+            // (e.g. another requirement was renamed onto the deleted HRID, or
+            // a move landed back on the same path): the deletion is stale.
+            if live_paths.contains(&path) {
+                continue;
+            }
+            // The write that replaces this file failed, so this file is the
+            // only good copy; retry the deletion on the next flush.
+            if failed_writes.contains(&owner) {
+                deferred.insert(path, owner);
+                continue;
+            }
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                // Already gone: the deletion's goal is achieved.
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    failures.push((path.clone(), e));
+                    deferred.insert(path, owner);
+                }
+            }
+        }
+        self.deletions = deferred;
 
         if let Some(failures) = NonEmpty::from_vec(failures) {
             return Err(FlushError { failures });
         }
-
-        // Process deletions
-        for path in &self.deletions {
-            if path.exists() {
-                if let Err(e) = std::fs::remove_file(path) {
-                    eprintln!("Warning: Failed to delete {}: {}", path.display(), e);
-                }
-            }
-        }
-        self.deletions.clear();
-
         Ok(flushed)
     }
 }
@@ -1158,7 +1177,7 @@ impl fmt::Display for FlushError {
             .failures
             .iter()
             .take(MAX_DISPLAY)
-            .map(|(p, _e)| p.display().to_string())
+            .map(|(p, e)| format!("{} ({e})", p.display()))
             .collect();
 
         let msg = displayed_paths.join(", ");
@@ -1672,5 +1691,112 @@ created: 2025-01-01T00:00:00Z
 
         // Verify both can be flushed without error
         assert!(dir.flush().is_ok());
+    }
+
+    #[test]
+    fn add_requirement_records_path() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir.add_requirement("REQ", String::new()).unwrap();
+
+        let expected = dir.canonical_path_for(req.hrid());
+        assert_eq!(dir.path_for(req.hrid()), Some(expected.as_path()));
+    }
+
+    #[test]
+    fn rename_after_flush_removes_old_file() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir.add_requirement("REQ", String::new()).unwrap();
+        dir.flush().unwrap();
+
+        let old_path = dir.root.join("REQ-001.md");
+        assert!(old_path.exists());
+
+        let new_hrid = Hrid::from_str("SYS-001").unwrap();
+        dir.rename_requirement(req.hrid(), &new_hrid).unwrap();
+        dir.flush().unwrap();
+
+        assert!(!old_path.exists(), "stale file must be deleted on flush");
+        assert!(dir.root.join("SYS-001.md").exists());
+
+        // The store must reload cleanly (no duplicate UUIDs on disk).
+        let reloaded = Directory::new(dir.root.clone()).unwrap();
+        assert!(reloaded.find_by_hrid(&new_hrid).is_some());
+    }
+
+    #[test]
+    fn rename_before_first_flush_leaves_single_file() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir.add_requirement("REQ", String::new()).unwrap();
+
+        // Rename before the original file was ever written.
+        let new_hrid = Hrid::from_str("SYS-001").unwrap();
+        dir.rename_requirement(req.hrid(), &new_hrid).unwrap();
+        dir.flush().unwrap();
+
+        assert!(!dir.root.join("REQ-001.md").exists());
+        assert!(dir.root.join("SYS-001.md").exists());
+        assert!(Directory::new(dir.root.clone()).is_ok());
+    }
+
+    #[test]
+    fn rename_onto_deleted_hrid_keeps_new_file() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let doomed = dir.add_requirement("REQ", String::new()).unwrap();
+        let survivor = dir.add_requirement("REQ", String::new()).unwrap();
+        dir.flush().unwrap();
+
+        // Delete REQ-001, then rename REQ-002 onto the freed HRID, so the
+        // deleted requirement's path is also the survivor's write target.
+        dir.delete_requirement(doomed.hrid()).unwrap();
+        dir.rename_requirement(survivor.hrid(), doomed.hrid())
+            .unwrap();
+        dir.flush().unwrap();
+
+        assert!(dir.root.join("REQ-001.md").exists());
+        assert!(!dir.root.join("REQ-002.md").exists());
+
+        let reloaded = Directory::new(dir.root.clone()).unwrap();
+        let view = reloaded.find_by_hrid(doomed.hrid()).unwrap();
+        assert_eq!(*view.uuid, survivor.uuid());
+    }
+
+    #[test]
+    fn move_to_same_path_does_not_delete_file() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir.add_requirement("REQ", String::new()).unwrap();
+        dir.flush().unwrap();
+
+        let path = dir.path_for(req.hrid()).unwrap().to_path_buf();
+        dir.move_requirement(req.hrid(), path.clone()).unwrap();
+        dir.flush().unwrap();
+
+        assert!(path.exists(), "moving onto itself must not delete the file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_write_defers_deletion_and_retries() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir.add_requirement("REQ", String::new()).unwrap();
+        dir.flush().unwrap();
+
+        // Block the rename target with a directory so the write fails.
+        let target = dir.root.join("SYS-001.md");
+        std::fs::create_dir(&target).unwrap();
+
+        let new_hrid = Hrid::from_str("SYS-001").unwrap();
+        dir.rename_requirement(req.hrid(), &new_hrid).unwrap();
+        assert!(dir.flush().is_err());
+        assert!(
+            dir.root.join("REQ-001.md").exists(),
+            "the only good copy must not be deleted when its replacement failed to write"
+        );
+
+        // Unblock and retry: the flush heals itself.
+        std::fs::remove_dir(&target).unwrap();
+        dir.flush().unwrap();
+        assert!(!dir.root.join("REQ-001.md").exists());
+        assert!(target.exists());
+        assert!(Directory::new(dir.root.clone()).is_ok());
     }
 }

--- a/req-core/src/storage/directory.rs
+++ b/req-core/src/storage/directory.rs
@@ -36,9 +36,8 @@ pub struct Directory {
     /// Source paths for requirements that were loaded from disk.
     /// Used to save requirements back to their original location.
     paths: HashMap<Uuid, PathBuf>,
-    /// Paths to delete on flush, keyed by the UUID of the requirement whose
-    /// deletion, rename, or move queued them.
-    deletions: HashMap<PathBuf, Uuid>,
+    /// Paths to delete on flush.
+    deletions: HashSet<PathBuf>,
 }
 
 impl Directory {
@@ -165,7 +164,7 @@ impl Directory {
             config,
             dirty: HashSet::new(),
             paths,
-            deletions: HashMap::new(),
+            deletions: HashSet::new(),
         })
     }
 }
@@ -511,7 +510,7 @@ impl Directory {
 
         // Mark file for deletion
         if let Some(path) = self.paths.remove(&uuid) {
-            self.deletions.insert(path, uuid);
+            self.deletions.insert(path);
         }
 
         Ok(())
@@ -550,7 +549,7 @@ impl Directory {
 
         // Mark file for deletion
         if let Some(path) = self.paths.remove(&uuid) {
-            self.deletions.insert(path, uuid);
+            self.deletions.insert(path);
         }
 
         Ok(())
@@ -648,7 +647,7 @@ impl Directory {
         // old path was recorded (e.g. a requirement added and renamed before
         // ever being flushed) so the old file is always reconciled on flush.
         if let Some(old_path) = self.paths.remove(&uuid) {
-            self.deletions.insert(old_path, uuid);
+            self.deletions.insert(old_path);
         }
         let new_path = self.canonical_path_for(new_hrid);
         self.paths.insert(uuid, new_path);
@@ -728,7 +727,7 @@ impl Directory {
         // Update file path mapping
         if let Some(old_path) = self.paths.remove(&uuid) {
             // Mark old file for deletion
-            self.deletions.insert(old_path, uuid);
+            self.deletions.insert(old_path);
         }
 
         // Set new path
@@ -1121,9 +1120,8 @@ impl Directory {
         writes.sort_by(|a, b| a.2.cmp(&b.2));
 
         // Phase 2: perform all writes (each atomic). A failure must not abort
-        // the flush: skipping the deletion phase after a rename would leave
-        // two files with the same UUID and wedge the next load.
-        let mut failed_writes: HashSet<Uuid> = HashSet::new();
+        // the flush: skipping the reconciliation phase after a rename would
+        // leave two files with the same UUID and wedge the next load.
         for (uuid, requirement, path) in &writes {
             match requirement.save_to_path(path, digits) {
                 Ok(()) => {
@@ -1131,39 +1129,41 @@ impl Directory {
                     flushed.push(requirement.hrid().clone());
                 }
                 Err(err) => {
-                    failed_writes.insert(*uuid);
                     failures.push((path.clone(), err));
                 }
             }
         }
 
-        // Phase 3: reconcile and process deletions.
+        // Phase 3: reconcile and process deletions. A queued deletion is
+        // dropped (not executed) when its path is now the live location of
+        // some requirement (e.g. another requirement was renamed onto the
+        // deleted HRID, or a move landed back on the same path).
         let live_paths: HashSet<&PathBuf> = self.paths.values().collect();
-        let mut deferred: HashMap<PathBuf, Uuid> = HashMap::new();
-        for (path, owner) in self.deletions.drain() {
-            // The path was re-claimed as the live location of some requirement
-            // (e.g. another requirement was renamed onto the deleted HRID, or
-            // a move landed back on the same path): the deletion is stale.
-            if live_paths.contains(&path) {
-                continue;
-            }
-            // The write that replaces this file failed, so this file is the
-            // only good copy; retry the deletion on the next flush.
-            if failed_writes.contains(&owner) {
-                deferred.insert(path, owner);
-                continue;
-            }
-            match std::fs::remove_file(&path) {
-                Ok(()) => {}
-                // Already gone: the deletion's goal is achieved.
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    failures.push((path.clone(), e));
-                    deferred.insert(path, owner);
+        if failures.is_empty() {
+            let mut deferred: HashSet<PathBuf> = HashSet::new();
+            for path in self.deletions.drain() {
+                if live_paths.contains(&path) {
+                    continue;
+                }
+                match std::fs::remove_file(&path) {
+                    Ok(()) => {}
+                    // Already gone: the deletion's goal is achieved.
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        failures.push((path.clone(), e));
+                        deferred.insert(path);
+                    }
                 }
             }
+            self.deletions = deferred;
+        } else {
+            // Never remove files while the store is partially written: e.g.
+            // deleting an orphaned parent's file while a child's rewrite
+            // failed would strand on-disk references to a missing
+            // requirement. Stale deletions are dropped; the rest stay queued
+            // so a retried flush converges.
+            self.deletions.retain(|path| !live_paths.contains(path));
         }
-        self.deletions = deferred;
 
         if let Some(failures) = NonEmpty::from_vec(failures) {
             return Err(FlushError { failures });
@@ -1876,6 +1876,35 @@ created: 2025-01-01T00:00:00Z
         dir.flush().unwrap();
         assert!(!dir.root.join("REQ-001.md").exists());
         assert!(target.exists());
+        assert!(Directory::new(dir.root.clone()).is_ok());
+    }
+
+    #[test]
+    fn orphan_delete_defers_file_removal_when_child_write_fails() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let parent = dir.add_requirement("SYS", String::new()).unwrap();
+        let child = dir.add_requirement("REQ", String::new()).unwrap();
+        dir.link_requirement(child.hrid(), parent.hrid()).unwrap();
+        dir.flush().unwrap();
+
+        // Make the child's rewrite fail by replacing its file with a
+        // directory.
+        let child_path = dir.root.join("REQ-001.md");
+        std::fs::remove_file(&child_path).unwrap();
+        std::fs::create_dir(&child_path).unwrap();
+
+        dir.delete_and_orphan(parent.hrid()).unwrap();
+        assert!(dir.flush().is_err());
+        assert!(
+            dir.root.join("SYS-001.md").exists(),
+            "the parent file must not be removed while an orphaned child could not be rewritten"
+        );
+
+        // Unblock and retry: the flush converges.
+        std::fs::remove_dir(&child_path).unwrap();
+        dir.flush().unwrap();
+        assert!(!dir.root.join("SYS-001.md").exists());
+        assert!(child_path.exists());
         assert!(Directory::new(dir.root.clone()).is_ok());
     }
 }

--- a/req-core/src/storage/directory.rs
+++ b/req-core/src/storage/directory.rs
@@ -578,7 +578,7 @@ impl Directory {
 
         // BFS to find all descendants that would be orphaned
         while let Some(current_uuid) = queue.pop_front() {
-            let Some(current_view) = self.tree.find_by_uuid(current_uuid) else {
+            let Some(current_view) = self.tree.requirement(current_uuid) else {
                 continue;
             };
 
@@ -589,7 +589,7 @@ impl Directory {
                 }
 
                 // Count how many parents this child has that we're NOT deleting
-                let Some(child_view) = self.tree.find_by_uuid(child_uuid) else {
+                let Some(child_view) = self.tree.requirement(child_uuid) else {
                     continue;
                 };
 
@@ -987,7 +987,7 @@ impl Directory {
     /// Find a requirement by its UUID.
     #[must_use]
     pub fn find_by_uuid(&self, uuid: uuid::Uuid) -> Option<RequirementView<'_>> {
-        self.tree.find_by_uuid(uuid)
+        self.tree.requirement(uuid)
     }
 
     /// Accept a specific suspect link by updating its fingerprint.

--- a/req-core/src/storage/markdown.rs
+++ b/req-core/src/storage/markdown.rs
@@ -134,6 +134,21 @@ impl MarkdownRequirement {
         // power loss, and these are plain-text files typically tracked in git.
         let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
         self.write(&mut tmp, digits)?;
+
+        // The temp file is created owner-only on Unix and persist replaces
+        // the destination inode, so carry over the destination's existing
+        // permissions (or the conventional 0o644 for new files) to avoid
+        // silently making shared-readable requirement files private.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = std::fs::metadata(file_path).map_or_else(
+                |_| std::fs::Permissions::from_mode(0o644),
+                |metadata| metadata.permissions(),
+            );
+            tmp.as_file().set_permissions(permissions)?;
+        }
+
         tmp.persist(file_path).map_err(|e| e.error)?;
         Ok(())
     }
@@ -707,6 +722,33 @@ created: not-a-date
             .map(|e| e.unwrap().file_name())
             .collect();
         assert_eq!(entries, vec![std::ffi::OsString::from("REQ-001.md")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_to_path_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("REQ-001.md");
+        let requirement = MarkdownRequirement {
+            frontmatter: create_test_frontmatter(),
+            hrid: req_hrid(),
+            title: "Title".to_string(),
+            body: String::new(),
+        };
+
+        // New files get the conventional world-readable mode, not the
+        // temp file's owner-only mode.
+        requirement.save_to_path(&path, 3).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o644);
+
+        // Overwriting keeps the destination's existing mode.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o664)).unwrap();
+        requirement.save_to_path(&path, 3).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o664);
     }
 
     #[cfg(unix)]

--- a/req-core/src/storage/markdown.rs
+++ b/req-core/src/storage/markdown.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeSet,
     fs::File,
-    io::{self, BufRead, BufReader, BufWriter, Write},
+    io::{self, BufRead, BufReader, Write},
     path::Path,
 };
 
@@ -28,7 +28,8 @@ pub struct MarkdownRequirement {
 
 impl MarkdownRequirement {
     fn write<W: Write>(&self, writer: &mut W, digits: usize) -> io::Result<()> {
-        let frontmatter = serde_yaml::to_string(&self.frontmatter).expect("this must never fail");
+        let frontmatter = serde_yaml::to_string(&self.frontmatter)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // Construct the heading with HRID and title
         let heading = format!("# {} {}", self.hrid.display(digits), self.title);
@@ -120,14 +121,21 @@ impl MarkdownRequirement {
     ///
     /// Returns an error if the file cannot be created or written to.
     pub fn save_to_path(&self, file_path: &Path, digits: usize) -> io::Result<()> {
-        // Create parent directories if needed
-        if let Some(parent) = file_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        let dir = file_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(dir)?;
 
-        let file = File::create(file_path)?;
-        let mut writer = BufWriter::new(file);
-        self.write(&mut writer, digits)
+        // Write to a temporary file in the same directory, then rename it over
+        // the destination. The rename is atomic on both Unix and Windows, so a
+        // crash mid-write can never leave a truncated requirement behind. We
+        // deliberately skip fsync: the threat model is crash-truncation, not
+        // power loss, and these are plain-text files typically tracked in git.
+        let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+        self.write(&mut tmp, digits)?;
+        tmp.persist(file_path).map_err(|e| e.error)?;
+        Ok(())
     }
 
     /// Reads a requirement using the given configuration.
@@ -672,6 +680,63 @@ created: not-a-date
         assert_eq!(loaded_requirement.title, title);
         assert_eq!(loaded_requirement.body, body);
         assert_eq!(loaded_requirement.frontmatter, frontmatter);
+    }
+
+    #[test]
+    fn save_to_path_overwrite_leaves_single_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("REQ-001.md");
+
+        let mut requirement = MarkdownRequirement {
+            frontmatter: create_test_frontmatter(),
+            hrid: req_hrid(),
+            title: "First".to_string(),
+            body: "first body".to_string(),
+        };
+        requirement.save_to_path(&path, 3).unwrap();
+
+        requirement.body = "second body".to_string();
+        requirement.save_to_path(&path, 3).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("second body"));
+
+        // The atomic write must not leave temporary files behind.
+        let entries: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("REQ-001.md")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_save_preserves_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("REQ-001.md");
+
+        let mut requirement = MarkdownRequirement {
+            frontmatter: create_test_frontmatter(),
+            hrid: req_hrid(),
+            title: "First".to_string(),
+            body: "original body".to_string(),
+        };
+        requirement.save_to_path(&path, 3).unwrap();
+
+        // Make the directory read-only so the temp file cannot be created.
+        let original_perms = std::fs::metadata(temp_dir.path()).unwrap().permissions();
+        std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        requirement.body = "replacement body".to_string();
+        let result = requirement.save_to_path(&path, 3);
+
+        std::fs::set_permissions(temp_dir.path(), original_perms).unwrap();
+
+        assert!(result.is_err());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("original body"));
     }
 
     #[test]

--- a/req-mcp/README.md
+++ b/req-mcp/README.md
@@ -14,17 +14,17 @@ The server listens on stdin/stdout for JSON-RPC messages (MCP protocol).
 
 ## Tools
 
-### Implemented
 - **`list_requirement_kinds`**: List all requirement kinds
 - **`list_requirements`**: List requirements by kind with optional substring filtering
 - **`get_requirement`**: Fetch a requirement by HRID with title, body, parents, and children
 - **`get_children`**: Get direct child requirements
+- **`get_parents`** / **`get_ancestors`** / **`get_descendants`**: Traverse the requirement graph
+- **`review`**: List suspect parent-child links with fingerprint drift
 - **`create_requirement_kind`**: Create a new requirement kind
 - **`create_requirement`**: Create a new requirement with optional parent links
 - **`review_requirement`**: Mark a suspect parent-child link as reviewed
 
-### Not Yet Implemented
-- `search_requirements`, `review`, `get_parents`, `get_ancestors`, `get_descendants`, `update_requirement`
+Planned but not yet available: text search and in-place requirement updates.
 
 ## Local Setup
 

--- a/req-mcp/src/server.rs
+++ b/req-mcp/src/server.rs
@@ -30,7 +30,7 @@ impl ReqMcpServer {
     }
 
     pub(crate) fn parse_hrid(raw: &str) -> Result<Hrid, McpError> {
-        Hrid::try_from(raw).map_err(|error| {
+        Hrid::parse_lenient(raw).map_err(|error| {
             McpError::invalid_params(
                 "invalid HRID provided",
                 Some(json!({ "hrid": raw, "reason": error.to_string() })),

--- a/req-mcp/src/server.rs
+++ b/req-mcp/src/server.rs
@@ -44,18 +44,6 @@ impl ReqMcpServer {
         result
     }
 
-    pub(crate) fn stub(tool: &str, params: Option<Value>) -> CallToolResult {
-        let message = format!("{tool} is not implemented yet");
-        let mut result = CallToolResult::success(vec![ContentBlock::text(message)]);
-        result.is_error = Some(true);
-        result.structured_content = Some(json!({
-            "status": "not_implemented",
-            "tool": tool,
-            "params": params.unwrap_or(Value::Null),
-        }));
-        result
-    }
-
     pub(crate) fn serialize<T: Serialize>(value: T, context: &str) -> Result<Value, McpError> {
         serde_json::to_value(value).map_err(|error| {
             McpError::internal_error(

--- a/req-mcp/src/tools.rs
+++ b/req-mcp/src/tools.rs
@@ -75,22 +75,6 @@ impl ReqMcpServer {
     }
 
     #[tool(
-        description = "Search requirements by text or regex (not implemented yet)",
-        annotations(
-            title = "Search Requirements",
-            read_only_hint = true,
-            idempotent_hint = true,
-            open_world_hint = false
-        )
-    )]
-    async fn search_requirements(
-        &self,
-        params: Parameters<search::SearchRequirementsParams>,
-    ) -> Result<CallToolResult, McpError> {
-        search::search_requirements(self, params).await
-    }
-
-    #[tool(
         description = "List suspect parent-child links where stored fingerprints drifted; start \
                        here before marking reviewed",
         annotations(
@@ -190,23 +174,6 @@ impl ReqMcpServer {
     }
 
     #[tool(
-        description = "Update a requirement's title, body, parents, or tags (not implemented yet)",
-        annotations(
-            title = "Update Requirement",
-            read_only_hint = false,
-            destructive_hint = true,
-            idempotent_hint = false,
-            open_world_hint = false
-        )
-    )]
-    async fn update_requirement(
-        &self,
-        params: Parameters<editing::UpdateRequirementParams>,
-    ) -> Result<CallToolResult, McpError> {
-        editing::update_requirement(self, params).await
-    }
-
-    #[tool(
         description = "Mark a suspect link as reviewed by refreshing the stored parent \
                        fingerprint on the child",
         annotations(
@@ -243,8 +210,7 @@ impl ServerHandler for ReqMcpServer {
              get_parents(hrid), get_ancestors(hrid), or get_descendants(hrid). Create new \
              kinds/requirements with create_requirement_kind and create_requirement. For link \
              drift, call review to list suspect child→parent links (fingerprint mismatches), then \
-             review_requirement to accept if the child still satisfies the parent. Search/update \
-             tools remain placeholders for now."
+             review_requirement to accept if the child still satisfies the parent."
                 .to_owned(),
         );
         info

--- a/req-mcp/src/tools/editing.rs
+++ b/req-mcp/src/tools/editing.rs
@@ -51,25 +51,6 @@ pub struct CreateRequirementParams {
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct UpdateRequirementParams {
-    /// HRID of the requirement to update.
-    pub hrid: String,
-    /// Updated title (optional).
-    #[serde(default)]
-    pub title: Option<String>,
-    /// Updated body (optional).
-    #[serde(default)]
-    pub body: Option<String>,
-    /// Replace parent HRIDs (optional).
-    #[serde(default)]
-    pub parents: Option<Vec<String>>,
-    /// Replace tags (optional).
-    #[serde(default)]
-    pub tags: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct ReviewRequirementParams {
     /// Child HRID whose link is being reviewed.
     pub child: String,
@@ -328,20 +309,6 @@ pub(super) async fn create_requirement(
     Ok(ReqMcpServer::success(
         summary,
         ReqMcpServer::serialize(response, "create_requirement response")?,
-    ))
-}
-
-#[allow(clippy::unused_async)]
-pub(super) async fn update_requirement(
-    _server: &ReqMcpServer,
-    params: Parameters<UpdateRequirementParams>,
-) -> Result<CallToolResult, McpError> {
-    Ok(ReqMcpServer::stub(
-        "update_requirement",
-        Some(ReqMcpServer::serialize(
-            &params.0,
-            "update_requirement params",
-        )?),
     ))
 }
 

--- a/req-mcp/src/tools/search.rs
+++ b/req-mcp/src/tools/search.rs
@@ -5,16 +5,6 @@ use crate::server::ReqMcpServer;
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SearchRequirementsParams {
-    /// Text or regex-like query for requirement content.
-    pub query: String,
-    /// Optional kind filter.
-    #[serde(default)]
-    pub kind: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct ReviewParams {
     /// Optional kind filter for review queries.
     #[serde(default)]
@@ -42,20 +32,6 @@ pub struct ReviewResponse {
     pub kind: Option<String>,
     /// Suspect links needing review.
     pub suspect_links: Vec<SuspectLinkView>,
-}
-
-#[allow(clippy::unused_async)]
-pub(super) async fn search_requirements(
-    _server: &ReqMcpServer,
-    params: Parameters<SearchRequirementsParams>,
-) -> Result<CallToolResult, McpError> {
-    Ok(ReqMcpServer::stub(
-        "search_requirements",
-        Some(ReqMcpServer::serialize(
-            &params.0,
-            "search_requirements params",
-        )?),
-    ))
 }
 
 #[allow(clippy::unused_async)]

--- a/req/Cargo.toml
+++ b/req/Cargo.toml
@@ -17,34 +17,22 @@ path = "src/main.rs"
 [dependencies]
 requirements-manager-core = { path = "../req-core" }
 anyhow = "1.0.98"
-borsh = { version = "1.6.0", features = ["derive"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.51", features = ["derive"] }
-petgraph = "0.8"
-non-empty-string = "0.2.6"
 nonempty = "0.12.0"
-rayon = "1.10.0"
+owo-colors = "4.1.0"
+regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_yaml = "0.9.34"
-sha2 = "0.10.9"
-thiserror = "2.0.12"
+serde_json = "1.0.138"
+supports-color = "3.0.1"
+terminal_size = "0.4.1"
 toml = "0.9.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
-walkdir = "2.5.0"
-regex = "1.11.1"
-serde_json = "1.0.138"
-dialoguer = "0.12.0"
-owo-colors = "4.1.0"
-supports-color = "3.0.1"
-indicatif = "0.18.3"
-terminal_size = "0.4.1"
 
 [dev-dependencies]
-criterion = "0.8.2"
 tempfile = "3.20.0"
-test-case = "3.3.1"
 
 [lints]
 workspace = true

--- a/req/Cargo.toml
+++ b/req/Cargo.toml
@@ -29,6 +29,7 @@ terminal_size = "0.4.1"
 toml = "0.9.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+unicode-width = "0.2.2"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/req/src/cli.rs
+++ b/req/src/cli.rs
@@ -28,7 +28,7 @@ use show::Show;
 use validate::Validate;
 
 /// Parse an HRID from a CLI argument, normalizing the KIND segment to
-/// uppercase for user convenience. For example: `auth-sys-001` → `auth-SYS-001`
+/// uppercase for user convenience: `auth-sys-001` → `auth-SYS-001`.
 fn parse_hrid(s: &str) -> Result<Hrid, String> {
     Hrid::parse_lenient(s).map_err(|e| e.to_string())
 }

--- a/req/src/cli.rs
+++ b/req/src/cli.rs
@@ -1,4 +1,7 @@
-use std::{io::BufRead, path::PathBuf};
+use std::{
+    io::{self, BufRead},
+    path::PathBuf,
+};
 
 mod config;
 mod create;
@@ -18,7 +21,6 @@ mod terminal;
 mod unlink;
 mod validate;
 
-use borsh::io;
 use clap::ArgAction;
 use list::List;
 use requiem_core::Hrid;

--- a/req/src/cli.rs
+++ b/req/src/cli.rs
@@ -27,34 +27,10 @@ use requiem_core::Hrid;
 use show::Show;
 use validate::Validate;
 
-/// Parse an HRID from a string, normalizing only the KIND segment to uppercase.
-///
-/// This is a CLI boundary function that accepts lowercase namespaces
-/// but normalizes the kind (category) to uppercase for user convenience.
-/// For example: `auth-sys-001` → `auth-SYS-001`
+/// Parse an HRID from a CLI argument, normalizing the KIND segment to
+/// uppercase for user convenience. For example: `auth-sys-001` → `auth-SYS-001`
 fn parse_hrid(s: &str) -> Result<Hrid, String> {
-    // Split on '-' to normalize only the KIND segment (second-to-last position)
-    let parts: Vec<&str> = s.split('-').collect();
-    if parts.len() < 2 {
-        return Err("Invalid HRID format".to_string());
-    }
-
-    // Uppercase the kind segment (second-to-last position)
-    let kind_idx = parts.len() - 2;
-    let normalized = parts
-        .iter()
-        .enumerate()
-        .map(|(i, part)| {
-            if i == kind_idx {
-                part.to_uppercase()
-            } else {
-                (*part).to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("-");
-
-    normalized.parse().map_err(|e| format!("{e}"))
+    Hrid::parse_lenient(s).map_err(|e| e.to_string())
 }
 
 #[derive(Debug, clap::Parser)]
@@ -207,74 +183,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_hrid_uppercase_kind() {
-        let result = parse_hrid("SYSTEM-AUTH-REQ-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "SYSTEM-AUTH-REQ-001");
-    }
-
-    #[test]
-    fn parse_hrid_lowercase_kind_normalization() {
+    fn parse_hrid_normalizes_kind_and_reports_errors_as_strings() {
         let result = parse_hrid("auth-sys-001").unwrap();
         assert_eq!(result.display(3).to_string(), "auth-SYS-001");
-    }
 
-    #[test]
-    fn parse_hrid_mixed_case_kind_normalization() {
-        let result = parse_hrid("auth-SyS-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "auth-SYS-001");
-    }
-
-    #[test]
-    fn parse_hrid_lowercase_namespace_preserved() {
-        let result = parse_hrid("auth-api-SYS-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "auth-api-SYS-001");
-    }
-
-    #[test]
-    fn parse_hrid_mixed_case_namespace_preserved() {
-        let result = parse_hrid("Auth-Api-SYS-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "Auth-Api-SYS-001");
-    }
-
-    #[test]
-    fn parse_hrid_no_namespace() {
-        let result = parse_hrid("req-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "REQ-001");
-    }
-
-    #[test]
-    fn parse_hrid_lowercase_no_namespace() {
-        let result = parse_hrid("req-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "REQ-001");
-    }
-
-    #[test]
-    fn parse_hrid_too_few_segments() {
-        let result = parse_hrid("invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_hrid_invalid_id() {
-        let result = parse_hrid("auth-SYS-invalid");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_hrid_zero_id() {
-        let result = parse_hrid("auth-SYS-000");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_hrid_long_namespace() {
-        let result = parse_hrid("a-b-c-d-SYS-001").unwrap();
-        assert_eq!(result.display(3).to_string(), "a-b-c-d-SYS-001");
-    }
-
-    #[test]
-    fn parse_hrid_large_id() {
-        let result = parse_hrid("auth-SYS-99999").unwrap();
-        assert_eq!(result.display(5).to_string(), "auth-SYS-99999");
+        assert!(parse_hrid("invalid").is_err());
     }
 }

--- a/req/src/cli.rs
+++ b/req/src/cli.rs
@@ -166,8 +166,10 @@ impl Command {
     }
 }
 
-fn prompt_to_proceed() -> io::Result<()> {
-    eprint!("\nProceed? (y/N) ");
+/// Ask a yes/no question on stderr; anything but "y" cancels by exiting with
+/// status 130.
+fn confirm(question: &str) -> io::Result<()> {
+    eprint!("\n{question} (y/N) ");
     let stdin = std::io::stdin();
     let mut line = String::new();
     stdin.lock().read_line(&mut line)?;
@@ -176,6 +178,10 @@ fn prompt_to_proceed() -> io::Result<()> {
         std::process::exit(130);
     }
     Ok(())
+}
+
+fn prompt_to_proceed() -> io::Result<()> {
+    confirm("Proceed?")
 }
 
 #[cfg(test)]

--- a/req/src/cli/diagnose.rs
+++ b/req/src/cli/diagnose.rs
@@ -26,30 +26,19 @@ impl Command {
                 let digits = directory.config().digits();
                 let mut issues: Vec<String> = Vec::new();
 
-                for req in directory.requirements() {
-                    // Get the actual path where this requirement was loaded from
-                    let Some(actual_path) = directory.path_for(req.hrid) else {
-                        continue; // Skip if path not found (shouldn't happen)
-                    };
-
-                    // Get the expected canonical path based on config
-                    let expected_path = directory.canonical_path_for(req.hrid);
-
-                    if actual_path != expected_path {
-                        let hrid = req.hrid;
-                        let expected_display = expected_path
-                            .strip_prefix(root)
-                            .unwrap_or(&expected_path)
-                            .display();
-                        let actual_display = actual_path
-                            .strip_prefix(root)
-                            .unwrap_or(actual_path)
-                            .display();
-                        issues.push(format!(
-                            "{}: Expected '{expected_display}', found '{actual_display}'",
-                            hrid.display(digits)
-                        ));
-                    }
+                for (hrid, actual_path, expected_path) in directory.check_path_drift() {
+                    let expected_display = expected_path
+                        .strip_prefix(root)
+                        .unwrap_or(&expected_path)
+                        .display();
+                    let actual_display = actual_path
+                        .strip_prefix(root)
+                        .unwrap_or(&actual_path)
+                        .display();
+                    issues.push(format!(
+                        "{}: Expected '{expected_display}', found '{actual_display}'",
+                        hrid.display(digits)
+                    ));
                 }
 
                 if issues.is_empty() {

--- a/req/src/cli/list.rs
+++ b/req/src/cli/list.rs
@@ -296,12 +296,8 @@ impl List {
         };
 
         let total_rows = rows.len();
-        let truncated = total_rows > effective_limit.unwrap_or(usize::MAX);
-        let truncated_count = if truncated {
-            total_rows.saturating_sub(effective_limit.unwrap_or(0))
-        } else {
-            0
-        };
+        let truncated_count = truncation_count(total_rows, self.offset, effective_limit);
+        let truncated = truncated_count > 0;
 
         rows = apply_offset_limit(rows, self.offset, effective_limit);
 
@@ -345,9 +341,11 @@ impl List {
                 "none".to_string()
             };
 
-            let limit_str = self
-                .limit
-                .map_or_else(|| DEFAULT_LIMIT.to_string(), |l| l.to_string());
+            let limit_str = match self.limit {
+                None => DEFAULT_LIMIT.to_string(),
+                Some(0) => "unlimited".to_string(),
+                Some(limit) => limit.to_string(),
+            };
 
             println!(
                 "{}",
@@ -833,18 +831,6 @@ where
     results
 }
 
-#[allow(dead_code)]
-fn append_unique_rows(rows: &mut Vec<Row>, new_rows: Vec<Row>) {
-    let mut existing: HashSet<(usize, Direction)> =
-        rows.iter().map(|row| (row.index, row.direction)).collect();
-
-    for row in new_rows {
-        if existing.insert((row.index, row.direction)) {
-            rows.push(row);
-        }
-    }
-}
-
 fn apply_sort(
     mut rows: Vec<Row>,
     entries: &[Entry],
@@ -904,6 +890,13 @@ fn compare_rows(
     } else {
         primary
     }
+}
+
+/// Number of rows cut off by the limit, not counting rows skipped by
+/// `--offset`.
+fn truncation_count(total_rows: usize, offset: Option<usize>, limit: Option<usize>) -> usize {
+    let remaining = total_rows.saturating_sub(offset.unwrap_or(0));
+    limit.map_or(0, |limit| remaining.saturating_sub(limit))
 }
 
 fn apply_offset_limit(mut rows: Vec<Row>, offset: Option<usize>, limit: Option<usize>) -> Vec<Row> {
@@ -1127,10 +1120,10 @@ fn render_table(
         .enumerate()
         .map(|(idx, header)| {
             data.iter()
-                .map(|row| strip_ansi(&row[idx]).len())
+                .map(|row| display_width(&row[idx]))
                 .max()
                 .unwrap_or(0)
-                .max(header.len())
+                .max(display_width(header))
         })
         .collect::<Vec<_>>();
 
@@ -1149,12 +1142,20 @@ fn render_table(
     for row in data {
         for (idx, value) in row.iter().enumerate() {
             let width = widths[idx];
-            let stripped_len = strip_ansi(value).len();
-            let padding = width.saturating_sub(stripped_len);
+            let padding = width.saturating_sub(display_width(value));
             print!("{value}{:padding$}  ", "");
         }
         println!();
     }
+}
+
+/// Terminal display width of a value, ignoring ANSI escape sequences.
+///
+/// Byte length would over-count any non-ASCII text (such as the `↑`/`↓`
+/// relationship markers, which are three bytes but one column wide) and
+/// misalign every subsequent column.
+fn display_width(text: &str) -> usize {
+    unicode_width::UnicodeWidthStr::width(strip_ansi(text).as_str())
 }
 
 fn highlight_match(text: &str, search: &str) -> String {
@@ -1707,15 +1708,24 @@ mod tests {
     }
 
     #[test]
-    fn append_unique_rows_avoids_duplicates() {
-        let mut rows = vec![row(0, Direction::None, 0)];
+    fn truncation_count_accounts_for_offset() {
+        // 10 rows, no offset, limit 4: 6 cut off.
+        assert_eq!(truncation_count(10, None, Some(4)), 6);
+        // 10 rows, skip 3, limit 4: rows 4-7 shown, 3 cut off.
+        assert_eq!(truncation_count(10, Some(3), Some(4)), 3);
+        // Offset past the end: nothing left to cut off.
+        assert_eq!(truncation_count(10, Some(20), Some(4)), 0);
+        // Unlimited: never truncated.
+        assert_eq!(truncation_count(10, Some(3), None), 0);
+    }
 
-        append_unique_rows(
-            &mut rows,
-            vec![row(0, Direction::None, 1), row(1, Direction::Down, 1)],
-        );
-
-        assert_eq!(rows.len(), 2);
+    #[test]
+    fn display_width_ignores_ansi_and_counts_columns() {
+        // ANSI escapes take no columns.
+        assert_eq!(display_width("\x1b[4mabc\x1b[24m"), 3);
+        // The relationship markers are multi-byte but single-column.
+        assert_eq!(display_width("\u{2191} SYS-001"), 9);
+        assert_eq!("\u{2191} SYS-001".len(), 11);
     }
 
     #[test]

--- a/req/src/cli/list.rs
+++ b/req/src/cli/list.rs
@@ -14,6 +14,8 @@ use serde::Serialize;
 use tracing::instrument;
 use uuid::Uuid;
 
+use super::parse_hrid;
+
 const DEFAULT_LIMIT: usize = 200;
 
 /// Command arguments for `req list`.
@@ -1413,10 +1415,6 @@ impl ListColumn {
     }
 }
 
-fn parse_hrid(value: &str) -> Result<Hrid, String> {
-    Hrid::try_from(value).map_err(|err| err.to_string())
-}
-
 impl fmt::Display for OutputFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -1905,12 +1903,6 @@ mod tests {
         assert_eq!(csv_escape("simple"), "simple");
         assert_eq!(csv_escape("needs,comma"), "\"needs,comma\"");
         assert_eq!(csv_escape("quote\"here"), "\"quote\"\"here\"");
-    }
-
-    #[test]
-    fn parse_hrid_accepts_valid_values() {
-        let hrid = parse_hrid("SYS-001").unwrap();
-        assert_eq!(hrid.display(3).to_string(), "SYS-001");
     }
 
     #[test]

--- a/req/src/cli/move.rs
+++ b/req/src/cli/move.rs
@@ -51,8 +51,6 @@ impl Command {
 
         // Show confirmation if --yes not specified
         if !self.yes {
-            use std::io::{self, BufRead};
-
             println!(
                 "Moving {} from {} to {}",
                 self.hrid.display(digits),
@@ -78,14 +76,7 @@ impl Command {
                 }
             }
 
-            eprint!("\nProceed? (y/N) ");
-            let stdin = io::stdin();
-            let mut line = String::new();
-            stdin.lock().read_line(&mut line)?;
-            if !line.trim().eq_ignore_ascii_case("y") {
-                println!("Cancelled");
-                std::process::exit(130);
-            }
+            super::prompt_to_proceed()?;
         }
 
         // Perform move

--- a/req/src/cli/rename.rs
+++ b/req/src/cli/rename.rs
@@ -1,4 +1,4 @@
-use std::{io::BufRead, path::PathBuf};
+use std::path::PathBuf;
 
 use requiem_core::{Directory, Hrid};
 use tracing::instrument;
@@ -54,14 +54,7 @@ impl Command {
                 }
             }
 
-            eprint!("\nProceed? (y/N) ");
-            let stdin = std::io::stdin();
-            let mut line = String::new();
-            stdin.lock().read_line(&mut line)?;
-            if !line.trim().eq_ignore_ascii_case("y") {
-                println!("Cancelled");
-                std::process::exit(130);
-            }
+            super::prompt_to_proceed()?;
         }
 
         // Perform rename

--- a/req/src/cli/review.rs
+++ b/req/src/cli/review.rs
@@ -1,4 +1,4 @@
-use std::{io::BufRead, path::PathBuf};
+use std::path::PathBuf;
 
 use requiem_core::{Directory, Hrid};
 use tracing::instrument;
@@ -200,7 +200,8 @@ impl Command {
 
         if parent_counts.len() > 1 {
             let mut parent_list: Vec<_> = parent_counts.iter().collect();
-            parent_list.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+            // Sort by HRID as a tiebreaker so equal counts print stably.
+            parent_list.sort_by_key(|(hrid, count)| (std::cmp::Reverse(*count), (*hrid).clone()));
 
             println!("Most affected parents:");
             for (hrid, count) in parent_list.iter().take(3) {
@@ -440,12 +441,13 @@ impl Command {
         directory: &Directory,
         digits: usize,
     ) {
-        use std::collections::HashMap;
+        use std::collections::BTreeMap;
 
         match self.group_by {
             Some(GroupBy::Parent) => {
-                let mut by_parent: HashMap<String, Vec<&requiem_core::SuspectLink>> =
-                    HashMap::new();
+                // BTreeMap keeps group output stable across runs.
+                let mut by_parent: BTreeMap<String, Vec<&requiem_core::SuspectLink>> =
+                    BTreeMap::new();
                 for link in suspect_links {
                     by_parent
                         .entry(link.parent_hrid.display(digits).to_string())
@@ -488,7 +490,8 @@ impl Command {
                 }
             }
             Some(GroupBy::Child) => {
-                let mut by_child: HashMap<String, Vec<&requiem_core::SuspectLink>> = HashMap::new();
+                let mut by_child: BTreeMap<String, Vec<&requiem_core::SuspectLink>> =
+                    BTreeMap::new();
                 for link in suspect_links {
                     by_child
                         .entry(link.child_hrid.display(digits).to_string())
@@ -572,8 +575,6 @@ impl Command {
 
             // Show preview and confirm
             if !self.yes {
-                use std::io::{self, BufRead};
-
                 println!("Will accept {count} suspect links across {file_count} files:");
                 for link in &suspect_links {
                     println!(
@@ -583,14 +584,7 @@ impl Command {
                     );
                 }
 
-                eprint!("\nProceed? (y/N) ");
-                let stdin = io::stdin();
-                let mut line = String::new();
-                stdin.lock().read_line(&mut line)?;
-                if !line.trim().eq_ignore_ascii_case("y") {
-                    println!("Cancelled");
-                    std::process::exit(130);
-                }
+                super::prompt_to_proceed()?;
             }
 
             // Accept all
@@ -625,14 +619,7 @@ impl Command {
                     println!("Stored:    {}", link.stored_fingerprint);
                     println!("Current:   {}", link.current_fingerprint);
 
-                    eprint!("\nAccept this link? (y/N) ");
-                    let stdin = std::io::stdin();
-                    let mut input = String::new();
-                    stdin.lock().read_line(&mut input)?;
-                    if !input.trim().eq_ignore_ascii_case("y") {
-                        println!("Cancelled");
-                        std::process::exit(130);
-                    }
+                    super::confirm("Accept this link?")?;
                 }
             }
 

--- a/req/src/cli/show.rs
+++ b/req/src/cli/show.rs
@@ -43,8 +43,7 @@ impl Show {
 
         // Find the requirement
         let Some(req) = directory.find_by_hrid(&self.hrid) else {
-            eprintln!("Requirement {} not found", self.hrid.display(digits));
-            std::process::exit(1);
+            anyhow::bail!("Requirement {} not found", self.hrid.display(digits));
         };
 
         // Handle --edit flag
@@ -119,8 +118,7 @@ impl Show {
         if !req.children.is_empty() {
             println!("\n{}", "Children".dim());
             for child_uuid in &req.children {
-                // Find child by UUID
-                if let Some(child) = directory.requirements().find(|r| r.uuid == child_uuid) {
+                if let Some(child) = directory.find_by_uuid(*child_uuid) {
                     println!("  • {} ({})", child.hrid.display(digits), child_uuid);
                 }
             }
@@ -157,13 +155,10 @@ impl Show {
             .children
             .iter()
             .map(|uuid| {
-                let hrid = directory
-                    .requirements()
-                    .find(|r| r.uuid == uuid)
-                    .map_or_else(
-                        || "unknown".to_string(),
-                        |r| r.hrid.display(digits).to_string(),
-                    );
+                let hrid = directory.find_by_uuid(*uuid).map_or_else(
+                    || "unknown".to_string(),
+                    |r| r.hrid.display(digits).to_string(),
+                );
                 json!({
                     "uuid": uuid.to_string(),
                     "hrid": hrid
@@ -230,7 +225,7 @@ impl Show {
         if !req.children.is_empty() {
             println!("\n## Children\n");
             for child_uuid in &req.children {
-                if let Some(child) = directory.requirements().find(|r| r.uuid == child_uuid) {
+                if let Some(child) = directory.find_by_uuid(*child_uuid) {
                     let hrid_display = child.hrid.display(directory.config().digits());
                     println!("- [{hrid_display}]({hrid_display}.md)");
                 }

--- a/req/src/cli/status.rs
+++ b/req/src/cli/status.rs
@@ -41,15 +41,7 @@ impl Command {
         let suspect_count = directory.suspect_links().len();
 
         // Check for path issues (files not at canonical locations)
-        let mut path_issues = 0;
-        for req in directory.requirements() {
-            if let Some(actual_path) = directory.path_for(req.hrid) {
-                let canonical_path = directory.canonical_path_for(req.hrid);
-                if actual_path != canonical_path {
-                    path_issues += 1;
-                }
-            }
-        }
+        let path_issues = directory.check_path_drift().len();
 
         // Check if we have an empty repository
         if total == 0 {

--- a/req/src/cli/sync.rs
+++ b/req/src/cli/sync.rs
@@ -174,8 +174,6 @@ impl Command {
 
         // Confirm before moving files
         if !self.yes {
-            use std::io::{self, BufRead};
-
             println!(
                 "Will move {} files to canonical locations:",
                 misplaced.len()
@@ -189,14 +187,7 @@ impl Command {
                 );
             }
 
-            eprint!("\nProceed? (y/N) ");
-            let stdin = io::stdin();
-            let mut line = String::new();
-            stdin.lock().read_line(&mut line)?;
-            if !line.trim().eq_ignore_ascii_case("y") {
-                println!("Cancelled");
-                std::process::exit(130);
-            }
+            super::prompt_to_proceed()?;
         }
 
         let moved = directory.sync_paths()?;
@@ -312,8 +303,6 @@ impl Command {
         hrid_drift: &[requiem_core::Hrid],
         path_drift: &[(requiem_core::Hrid, std::path::PathBuf, std::path::PathBuf)],
     ) -> anyhow::Result<()> {
-        use std::io::{self, BufRead};
-
         println!("Will synchronize:");
         if !hrid_drift.is_empty() {
             println!("  • Update {} parent HRIDs", hrid_drift.len());
@@ -322,14 +311,7 @@ impl Command {
             println!("  • Move {} files", path_drift.len());
         }
 
-        eprint!("\nProceed? (y/N) ");
-        let stdin = io::stdin();
-        let mut line = String::new();
-        stdin.lock().read_line(&mut line)?;
-        if !line.trim().eq_ignore_ascii_case("y") {
-            println!("Cancelled");
-            std::process::exit(130);
-        }
+        super::prompt_to_proceed()?;
         Ok(())
     }
 }

--- a/req/src/cli/validate.rs
+++ b/req/src/cli/validate.rs
@@ -182,22 +182,15 @@ impl Validate {
 
     fn check_paths(directory: &Directory) -> Vec<PathIssue> {
         let digits = directory.config().digits();
-        let mut issues = Vec::new();
-
-        for req in directory.requirements() {
-            if let Some(actual_path) = directory.path_for(req.hrid) {
-                let canonical_path = directory.canonical_path_for(req.hrid);
-                if actual_path != canonical_path {
-                    issues.push(PathIssue {
-                        hrid: req.hrid.display(digits).to_string(),
-                        current_path: actual_path.to_path_buf(),
-                        expected_path: canonical_path,
-                    });
-                }
-            }
-        }
-
-        issues
+        directory
+            .check_path_drift()
+            .into_iter()
+            .map(|(hrid, current_path, expected_path)| PathIssue {
+                hrid: hrid.display(digits).to_string(),
+                current_path,
+                expected_path,
+            })
+            .collect()
     }
 
     fn check_links(directory: &Directory) -> Vec<LinkIssue> {
@@ -452,20 +445,11 @@ impl Validate {
 
         // Confirm before fixing
         if !self.yes && !self.quiet {
-            use std::io::{self, BufRead};
-
             let fixable = result.count_fixable_issues();
             println!("\nWill fix {fixable} issues:");
             Self::preview_fixes(result);
 
-            eprint!("\nProceed? (y/N) ");
-            let stdin = io::stdin();
-            let mut line = String::new();
-            stdin.lock().read_line(&mut line)?;
-            if !line.trim().eq_ignore_ascii_case("y") {
-                println!("Cancelled");
-                std::process::exit(130);
-            }
+            super::prompt_to_proceed()?;
         }
 
         // Fix paths


### PR DESCRIPTION
A hardening pass over the whole workspace: storage durability, correctness bugs, dead dependencies, and copy-pasted logic. No public API signatures change and no modules are restructured; each commit is an independent, reviewable fix.

## Storage durability (req-core)

- **Atomic writes**: `MarkdownRequirement::save_to_path` and `Config::save` previously truncated the destination in place, so a crash or I/O error mid-write lost the file. Writes now go to a same-directory tempfile followed by an atomic rename (`tempfile` promoted from dev-dependency). The unflushed `BufWriter` (which silently swallowed late write errors) and a `serde_yaml` `.expect()` panic in the write path are also gone.
- **`flush()` reconciliation**: three data-loss/corruption bugs fixed —
  1. a path that was both a delete target and a write target (delete `REQ-001`, rename `REQ-002` onto it) had its freshly written file destroyed;
  2. an early return on the first write failure skipped deletions, leaving two files with the same UUID and wedging the next load with a `Duplicate` error;
  3. freshly added requirements were never recorded in the path map, so renaming them left the stale file behind.
  Flush now records all write targets, attempts every write, and reconciles deletions against live paths — deferring any deletion whose replacement failed to write. Deletion failures are real errors instead of `eprintln!` warnings, and retrying `flush()` converges.
- **Strict loading**: a malformed `.req/config.toml` no longer silently falls back to defaults (which flipped `subfolders_are_namespaces` and reinterpreted the store layout), and walkdir errors are no longer swallowed (requirements under an unreadable directory used to just vanish).

## Domain correctness (req-core)

- `cycles_equal` compared cycle rotations via substring containment on a doubled string built **without a separator**, so rotations wrapping the boundary were never detected; now an index-wise rotation comparison.
- `detect_cycles` recursed per graph depth and overflowed the stack on long parent chains; now iterative (test at 20k depth).
- `allowed_kinds = ["usr"]` in config.toml silently rejected every requirement (HRID kinds are uppercase, comparison was exact); kinds are now normalized on load.
- `accept_suspect_link` no longer clones a full requirement view just to hash content; `already_linked` is now an O(1) edge check; copy-pasted edge-reconstruction blocks are shared helpers; three stale `# Panics` doc sections corrected.

## CLI (req)

- Table alignment used **byte** length, so non-ASCII titles and the `↑`/`↓` markers misaligned every column; widths now use `unicode-width` on ANSI-stripped text.
- `review --group-by` iterated a `HashMap` — output order changed run to run; now `BTreeMap`.
- The `+N more` footer counted rows skipped by `--offset` as truncated; `limit: 0` header now prints `unlimited`.
- `req list auth-sys-001` and MCP tools rejected lowercase kinds that `req show` accepted; all entry points now share `Hrid::parse_lenient` in req-core.
- `req show` no longer hard-exits the process on a missing requirement and no longer does an O(n) scan per child; the hand-rolled path-drift loop in status/validate/diagnose now calls `Directory::check_path_drift()`; the y/N prompt copy-pasted in seven places is one helper.

## MCP (req-mcp)

- `search_requirements` and `update_requirement` were advertised in the tool schema but only returned "not implemented yet" errors; they're unregistered, dead stub plumbing removed, and the README updated (it also listed several long-implemented tools as missing).

## Dependencies

Removed 11 unused dependencies: `regex` from req-core; `borsh`, `dialoguer`, `indicatif`, `non-empty-string`, `petgraph`, `rayon`, `serde_yaml`, `sha2`, `thiserror`, `walkdir` plus unused dev-deps `criterion`/`test-case` from req. Added `unicode-width` (already in the tree transitively).

Every behavioral fix lands with a regression test (atomic overwrite, flush reconciliation scenarios, malformed config, cycle rotation, deep chains, kind normalization, offset truncation, display width).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SndpD4UneHwuBuuexnTgpW)_