### PR TITLE
feat(mcp): add update, link/unlink, and delete requirement tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/req-core/src/domain/tree.rs
+++ b/req-core/src/domain/tree.rs
@@ -196,6 +196,43 @@ impl Tree {
         })
     }
 
+    /// Updates the content of the requirement with the given UUID.
+    ///
+    /// Fields passed as `None` are left unchanged. Returns `None` when no
+    /// requirement with this UUID exists, otherwise whether any field actually
+    /// changed.
+    pub fn update_requirement_content(
+        &mut self,
+        uuid: Uuid,
+        title: Option<String>,
+        body: Option<String>,
+        tags: Option<BTreeSet<String>>,
+    ) -> Option<bool> {
+        let data = self.requirements.get_mut(&uuid)?;
+
+        let mut changed = false;
+        if let Some(title) = title {
+            if data.title != title {
+                data.title = title;
+                changed = true;
+            }
+        }
+        if let Some(body) = body {
+            if data.body != body {
+                data.body = body;
+                changed = true;
+            }
+        }
+        if let Some(tags) = tags {
+            if data.tags != tags {
+                data.tags = tags;
+                changed = true;
+            }
+        }
+
+        Some(changed)
+    }
+
     /// Retrieves a requirement by UUID as a borrowed view.
     ///
     /// Note: Since UUID is passed by value, we need to find a way to get a

--- a/req-core/src/storage/directory/edit.rs
+++ b/req-core/src/storage/directory/edit.rs
@@ -1,6 +1,9 @@
-//! Adding, linking, renaming, moving, and deleting requirements.
+//! Adding, updating, linking, renaming, moving, and deleting requirements.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use super::Directory;
 use crate::{
@@ -128,6 +131,49 @@ impl Directory {
         );
 
         Ok(requirement)
+    }
+
+    /// Update the title, body, and/or tags of an existing requirement.
+    ///
+    /// Fields passed as `None` are left unchanged. Changing the body or tags
+    /// changes the requirement's fingerprint, so links from its children
+    /// become suspect and need review.
+    ///
+    /// Returns `true` if any field actually changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requirement does not exist.
+    pub fn update_requirement(
+        &mut self,
+        hrid: &Hrid,
+        title: Option<String>,
+        body: Option<String>,
+        tags: Option<BTreeSet<String>>,
+    ) -> anyhow::Result<bool> {
+        let Some(view) = self.tree.find_by_hrid(hrid) else {
+            anyhow::bail!(
+                "Requirement {} not found",
+                hrid.display(self.config.digits())
+            );
+        };
+        let uuid = *view.uuid;
+
+        let Some(changed) = self
+            .tree
+            .update_requirement_content(uuid, title, body, tags)
+        else {
+            anyhow::bail!(
+                "Requirement {} not found",
+                hrid.display(self.config.digits())
+            );
+        };
+
+        if changed {
+            self.mark_dirty(uuid);
+        }
+
+        Ok(changed)
     }
 
     /// Link two requirements together with a parent-child relationship.
@@ -655,6 +701,99 @@ mod tests {
 
         // Verify both can be flushed without error
         assert!(dir.flush().is_ok());
+    }
+
+    #[test]
+    fn update_requirement_changes_content_and_persists() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir
+            .add_requirement("REQ", "# Old title\n\nOld body".to_string())
+            .unwrap();
+        dir.flush().unwrap();
+
+        let changed = dir
+            .update_requirement(
+                req.hrid(),
+                Some("New title".to_string()),
+                Some("New body".to_string()),
+                Some(["tag1".to_string()].into()),
+            )
+            .unwrap();
+        assert!(changed);
+        dir.flush().unwrap();
+
+        let config = load_config(&dir.root).unwrap();
+        let updated = Requirement::load(&dir.root, req.hrid(), &config).unwrap();
+        assert_eq!(updated.title(), "New title");
+        assert_eq!(updated.body(), "New body");
+        assert_eq!(updated.tags(), &BTreeSet::from(["tag1".to_string()]));
+        // Identity is preserved across content updates.
+        assert_eq!(updated.uuid(), req.uuid());
+    }
+
+    #[test]
+    fn update_requirement_leaves_omitted_fields_unchanged() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir
+            .add_requirement("REQ", "# Title\n\nBody".to_string())
+            .unwrap();
+        dir.flush().unwrap();
+
+        let changed = dir
+            .update_requirement(req.hrid(), Some("Renamed".to_string()), None, None)
+            .unwrap();
+        assert!(changed);
+        dir.flush().unwrap();
+
+        let config = load_config(&dir.root).unwrap();
+        let updated = Requirement::load(&dir.root, req.hrid(), &config).unwrap();
+        assert_eq!(updated.title(), "Renamed");
+        assert_eq!(updated.body(), "Body");
+    }
+
+    #[test]
+    fn update_requirement_reports_no_change() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir
+            .add_requirement("REQ", "# Title\n\nBody".to_string())
+            .unwrap();
+        dir.flush().unwrap();
+
+        let changed = dir
+            .update_requirement(req.hrid(), Some("Title".to_string()), None, None)
+            .unwrap();
+        assert!(!changed);
+    }
+
+    #[test]
+    fn update_requirement_body_marks_child_links_suspect() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let parent = dir
+            .add_requirement("SYS", "# Parent\n\nOriginal".to_string())
+            .unwrap();
+        let child = dir.add_requirement("USR", "# Child".to_string()).unwrap();
+        dir.link_requirement(child.hrid(), parent.hrid()).unwrap();
+        dir.flush().unwrap();
+
+        let mut dir = Directory::new(dir.root.clone()).unwrap();
+        assert!(dir.suspect_links().is_empty());
+
+        dir.update_requirement(parent.hrid(), None, Some("Changed".to_string()), None)
+            .unwrap();
+
+        let suspects = dir.suspect_links();
+        assert_eq!(suspects.len(), 1);
+        assert_eq!(&suspects[0].child_hrid, child.hrid());
+        assert_eq!(&suspects[0].parent_hrid, parent.hrid());
+    }
+
+    #[test]
+    fn update_requirement_unknown_hrid_errors() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let missing: Hrid = "REQ-999".parse().unwrap();
+        assert!(dir
+            .update_requirement(&missing, Some("Title".to_string()), None, None)
+            .is_err());
     }
 
     #[test]

--- a/req-core/src/storage/directory/edit.rs
+++ b/req-core/src/storage/directory/edit.rs
@@ -139,11 +139,16 @@ impl Directory {
     /// changes the requirement's fingerprint, so links from its children
     /// become suspect and need review.
     ///
+    /// Values are normalized to what the markdown format round-trips: the
+    /// title is trimmed (it lives on the single heading line) and blank lines
+    /// surrounding the body are removed, matching what a reload would produce.
+    ///
     /// Returns `true` if any field actually changed.
     ///
     /// # Errors
     ///
-    /// Returns an error if the requirement does not exist.
+    /// Returns an error if the requirement does not exist or if the title
+    /// spans multiple lines (the heading cannot store it).
     pub fn update_requirement(
         &mut self,
         hrid: &Hrid,
@@ -151,6 +156,14 @@ impl Directory {
         body: Option<String>,
         tags: Option<BTreeSet<String>>,
     ) -> anyhow::Result<bool> {
+        let title = title.map(|title| title.trim().to_string());
+        if let Some(title) = &title {
+            if title.contains(['\n', '\r']) {
+                anyhow::bail!("Title must be a single line");
+            }
+        }
+        let body = body.map(|body| trim_empty_lines(&body));
+
         let Some(view) = self.tree.find_by_hrid(hrid) else {
             anyhow::bail!(
                 "Requirement {} not found",
@@ -785,6 +798,51 @@ mod tests {
         assert_eq!(suspects.len(), 1);
         assert_eq!(&suspects[0].child_hrid, child.hrid());
         assert_eq!(&suspects[0].parent_hrid, parent.hrid());
+    }
+
+    #[test]
+    fn update_requirement_rejects_multiline_title() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir
+            .add_requirement("REQ", "# Title\n\nBody".to_string())
+            .unwrap();
+
+        assert!(dir
+            .update_requirement(
+                req.hrid(),
+                Some("Line one\nLine two".to_string()),
+                None,
+                None
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn update_requirement_normalizes_to_round_trippable_content() {
+        let (_tmp, mut dir) = setup_temp_directory();
+        let req = dir
+            .add_requirement("REQ", "# Title\n\nBody".to_string())
+            .unwrap();
+        dir.flush().unwrap();
+
+        dir.update_requirement(
+            req.hrid(),
+            Some("  Padded title  ".to_string()),
+            Some("\n\nPadded body\n\n".to_string()),
+            None,
+        )
+        .unwrap();
+        dir.flush().unwrap();
+
+        // The stored values match what a reload from disk produces.
+        let view = dir.find_by_hrid(req.hrid()).unwrap();
+        let (in_memory_title, in_memory_body) = (view.title.to_string(), view.body.to_string());
+        let reloaded = Directory::new(dir.root.clone()).unwrap();
+        let reloaded_view = reloaded.find_by_hrid(req.hrid()).unwrap();
+        assert_eq!(reloaded_view.title, in_memory_title);
+        assert_eq!(reloaded_view.body, in_memory_body);
+        assert_eq!(in_memory_title, "Padded title");
+        assert_eq!(in_memory_body, "Padded body");
     }
 
     #[test]

--- a/req-mcp/Cargo.toml
+++ b/req-mcp/Cargo.toml
@@ -25,5 +25,8 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 schemars = { version = "1.0", features = ["derive"] }
 
+[dev-dependencies]
+tempfile = "3.20.0"
+
 [lints]
 workspace = true

--- a/req-mcp/README.md
+++ b/req-mcp/README.md
@@ -22,9 +22,12 @@ The server listens on stdin/stdout for JSON-RPC messages (MCP protocol).
 - **`review`**: List suspect parent-child links with fingerprint drift
 - **`create_requirement_kind`**: Create a new requirement kind
 - **`create_requirement`**: Create a new requirement with optional parent links
+- **`update_requirement`**: Update the title, body, and/or tags of an existing requirement in place
+- **`link_requirement`** / **`unlink_requirement`**: Manage parent-child traceability links between existing requirements
+- **`delete_requirement`**: Delete a requirement, with `refuse`/`orphan`/`cascade` handling for children and a dry-run preview
 - **`review_requirement`**: Mark a suspect parent-child link as reviewed
 
-Planned but not yet available: text search and in-place requirement updates.
+Planned but not yet available: cross-kind text search.
 
 ## Local Setup
 

--- a/req-mcp/src/tools.rs
+++ b/req-mcp/src/tools.rs
@@ -230,8 +230,8 @@ impl ReqMcpServer {
     }
 
     #[tool(
-        description = "Delete a requirement; mode controls children handling (refuse/orphan/\
-                       cascade) and dryRun previews without changing anything",
+        description = "Delete a requirement; mode controls children handling \
+                       (refuse/orphan/cascade) and dryRun previews without changing anything",
         annotations(
             title = "Delete Requirement",
             read_only_hint = false,
@@ -286,10 +286,10 @@ impl ServerHandler for ReqMcpServer {
              Fetch details with get_requirement(hrid) and traverse with get_children(hrid), \
              get_parents(hrid), get_ancestors(hrid), or get_descendants(hrid). Create new \
              kinds/requirements with create_requirement_kind and create_requirement. Edit \
-             existing requirements with update_requirement (title/body/tags), manage \
-             traceability with link_requirement and unlink_requirement, and remove requirements \
-             with delete_requirement (mode: refuse/orphan/cascade; dryRun to preview). For link \
-             drift, call review to list suspect child→parent links (fingerprint mismatches), then \
+             existing requirements with update_requirement (title/body/tags), manage traceability \
+             with link_requirement and unlink_requirement, and remove requirements with \
+             delete_requirement (mode: refuse/orphan/cascade; dryRun to preview). For link drift, \
+             call review to list suspect child→parent links (fingerprint mismatches), then \
              review_requirement to accept if the child still satisfies the parent."
                 .to_owned(),
         );

--- a/req-mcp/src/tools.rs
+++ b/req-mcp/src/tools.rs
@@ -177,6 +177,77 @@ impl ReqMcpServer {
     }
 
     #[tool(
+        description = "Update the title, body, and/or tags of an existing requirement in place; \
+                       omitted fields are left unchanged",
+        annotations(
+            title = "Update Requirement",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn update_requirement(
+        &self,
+        params: Parameters<editing::UpdateRequirementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        editing::update_requirement(self, params).await
+    }
+
+    #[tool(
+        description = "Link an existing requirement to a parent (child satisfies parent); \
+                       relinking an existing pair refreshes the stored fingerprint",
+        annotations(
+            title = "Link Requirement",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn link_requirement(
+        &self,
+        params: Parameters<editing::LinkRequirementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        editing::link_requirement(self, params).await
+    }
+
+    #[tool(
+        description = "Remove the parent-child link between two requirements",
+        annotations(
+            title = "Unlink Requirement",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn unlink_requirement(
+        &self,
+        params: Parameters<editing::UnlinkRequirementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        editing::unlink_requirement(self, params).await
+    }
+
+    #[tool(
+        description = "Delete a requirement; mode controls children handling (refuse/orphan/\
+                       cascade) and dryRun previews without changing anything",
+        annotations(
+            title = "Delete Requirement",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn delete_requirement(
+        &self,
+        params: Parameters<editing::DeleteRequirementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        editing::delete_requirement(self, params).await
+    }
+
+    #[tool(
         description = "Mark a suspect link as reviewed by refreshing the stored parent \
                        fingerprint on the child",
         annotations(
@@ -214,7 +285,10 @@ impl ServerHandler for ReqMcpServer {
              repo). Start with list_requirement_kinds, then list_requirements(kind) to get HRIDs. \
              Fetch details with get_requirement(hrid) and traverse with get_children(hrid), \
              get_parents(hrid), get_ancestors(hrid), or get_descendants(hrid). Create new \
-             kinds/requirements with create_requirement_kind and create_requirement. For link \
+             kinds/requirements with create_requirement_kind and create_requirement. Edit \
+             existing requirements with update_requirement (title/body/tags), manage \
+             traceability with link_requirement and unlink_requirement, and remove requirements \
+             with delete_requirement (mode: refuse/orphan/cascade; dryRun to preview). For link \
              drift, call review to list suspect child→parent links (fingerprint mismatches), then \
              review_requirement to accept if the child still satisfies the parent."
                 .to_owned(),

--- a/req-mcp/src/tools/editing.rs
+++ b/req-mcp/src/tools/editing.rs
@@ -448,10 +448,24 @@ pub(super) async fn update_requirement(
         ));
     }
 
+    // The title lives on the requirement's single markdown heading line, so a
+    // multi-line value cannot round-trip through storage.
+    if let Some(title) = &params.title
+        && title.trim().contains(['\n', '\r'])
+    {
+        return Err(McpError::invalid_params(
+            "`title` must be a single line",
+            Some(json!({ "field": "title" })),
+        ));
+    }
+
     let hrid = ReqMcpServer::parse_hrid(&params.hrid)?;
-    let tags: Option<BTreeSet<String>> = params
-        .tags
-        .map(|tags| tags.into_iter().map(|tag| tag.trim().to_string()).collect());
+    let tags: Option<BTreeSet<String>> = params.tags.map(|tags| {
+        tags.into_iter()
+            .map(|tag| tag.trim().to_string())
+            .filter(|tag| !tag.is_empty())
+            .collect()
+    });
 
     let mut directory = server.state.directory.write().await;
     let digits = directory.config().digits();
@@ -856,6 +870,42 @@ mod tests {
         .await
         .expect("no-op update should succeed");
         assert_eq!(structured(&result)["changed"], Value::Bool(false));
+    }
+
+    #[tokio::test]
+    async fn update_requirement_normalizes_content() {
+        let (_tmp, server) = server_with_root();
+        let hrid = create(&server, "REQ", "Title", vec![]).await;
+
+        // A multi-line title cannot round-trip through the markdown heading.
+        let result = update_requirement(
+            &server,
+            Parameters(UpdateRequirementParams {
+                hrid: hrid.clone(),
+                title: Some("Line one\nLine two".to_string()),
+                body: None,
+                tags: None,
+            }),
+        )
+        .await;
+        assert!(result.is_err());
+
+        // Padding is normalized to what a reload would produce.
+        let result = update_requirement(
+            &server,
+            Parameters(UpdateRequirementParams {
+                hrid,
+                title: Some("  Padded title  ".to_string()),
+                body: Some("\n\nPadded body\n\n".to_string()),
+                tags: Some(vec!["  ".to_string(), "kept".to_string()]),
+            }),
+        )
+        .await
+        .expect("update should succeed");
+        let data = structured(&result);
+        assert_eq!(data["requirement"]["title"], "Padded title");
+        assert_eq!(data["requirement"]["body"], "Padded body");
+        assert_eq!(data["requirement"]["tags"], serde_json::json!(["kept"]));
     }
 
     #[tokio::test]

--- a/req-mcp/src/tools/editing.rs
+++ b/req-mcp/src/tools/editing.rs
@@ -630,8 +630,8 @@ pub(super) async fn delete_requirement(
 
     if params.mode == DeleteMode::Refuse && !children.is_empty() {
         return Err(McpError::invalid_params(
-            "requirement has children; use mode `orphan` to keep them or `cascade` to also \
-             delete orphaned descendants",
+            "requirement has children; use mode `orphan` to keep them or `cascade` to also delete \
+             orphaned descendants",
             Some(json!({
                 "hrid": ReqMcpServer::format_hrid(&hrid, digits),
                 "children": children

--- a/req-mcp/src/tools/editing.rs
+++ b/req-mcp/src/tools/editing.rs
@@ -1,6 +1,6 @@
-//! Editing tools: create, update, link, and review requirements.
+//! Editing tools: create, update, link, delete, and review requirements.
 
-use std::fs;
+use std::{collections::BTreeSet, fs};
 
 use requiem_core::{Directory, Hrid, LinkRequirementError};
 use rmcp::{handler::server::wrapper::Parameters, model::CallToolResult, ErrorData as McpError};
@@ -53,6 +53,113 @@ pub struct CreateRequirementParams {
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct UpdateRequirementParams {
+    /// HRID of the requirement to update.
+    pub hrid: String,
+    /// New title (omit to leave unchanged).
+    #[serde(default)]
+    pub title: Option<String>,
+    /// New markdown body (omit to leave unchanged).
+    #[serde(default)]
+    pub body: Option<String>,
+    /// Replacement set of tags (omit to leave unchanged).
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateRequirementResponse {
+    /// Whether any field actually changed.
+    pub changed: bool,
+    /// The requirement after the update.
+    pub requirement: RequirementDetails,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkRequirementParams {
+    /// Child HRID.
+    pub child: String,
+    /// Parent HRID to link the child to.
+    pub parent: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkRequirementResponse {
+    /// Child HRID.
+    pub child: String,
+    /// Parent HRID.
+    pub parent: String,
+    /// Whether the link already existed. Relinking an existing pair refreshes
+    /// the stored parent fingerprint (equivalent to accepting a suspect link).
+    pub already_linked: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlinkRequirementParams {
+    /// Child HRID.
+    pub child: String,
+    /// Parent HRID to unlink the child from.
+    pub parent: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlinkRequirementResponse {
+    /// Child HRID.
+    pub child: String,
+    /// Parent HRID the child was unlinked from.
+    pub parent: String,
+}
+
+/// How `delete_requirement` handles children of the deleted requirement.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum DeleteMode {
+    /// Fail if the requirement has children (default).
+    #[default]
+    Refuse,
+    /// Delete the requirement and unlink it from its children; the children
+    /// are kept.
+    Orphan,
+    /// Delete the requirement together with all descendants that would be
+    /// left without any parent.
+    Cascade,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteRequirementParams {
+    /// HRID of the requirement to delete.
+    pub hrid: String,
+    /// How to handle children: "refuse" (default), "orphan", or "cascade".
+    #[serde(default)]
+    pub mode: DeleteMode,
+    /// Preview what would be deleted without changing anything.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteRequirementResponse {
+    /// Mode that was applied.
+    pub mode: DeleteMode,
+    /// Whether this was a dry run (nothing was changed).
+    pub dry_run: bool,
+    /// HRIDs deleted (or that would be deleted for a dry run).
+    pub deleted: Vec<String>,
+    /// Children that were unlinked from a deleted requirement but kept.
+    pub unlinked_children: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ReviewRequirementParams {
     /// Child HRID whose link is being reviewed.
     pub child: String,
@@ -69,6 +176,51 @@ pub struct ReviewRequirementResponse {
     pub parent: String,
     /// Outcome of the review.
     pub status: String,
+}
+
+/// Build the full details view for a requirement that is known to exist.
+fn requirement_details(
+    directory: &Directory,
+    hrid: &requiem_core::Hrid,
+    digits: usize,
+) -> Result<RequirementDetails, McpError> {
+    let Some(view) = directory.find_by_hrid(hrid) else {
+        return Err(McpError::internal_error(
+            "requirement could not be reloaded",
+            Some(json!({ "hrid": ReqMcpServer::format_hrid(hrid, digits) })),
+        ));
+    };
+
+    let parents = view
+        .parents
+        .iter()
+        .map(|(_, parent)| ReqMcpServer::format_hrid(&parent.hrid, digits))
+        .collect();
+
+    let children = directory
+        .children_of(hrid)
+        .iter()
+        .map(|child| ReqMcpServer::format_hrid(child, digits))
+        .collect();
+
+    Ok(RequirementDetails {
+        hrid: ReqMcpServer::format_hrid(hrid, digits),
+        title: view.title.to_string(),
+        body: view.body.to_string(),
+        tags: view.tags.iter().cloned().collect(),
+        parents,
+        children,
+    })
+}
+
+/// Persist pending changes, mapping failures to an MCP error.
+fn flush(directory: &mut Directory) -> Result<(), McpError> {
+    directory.flush().map(|_| ()).map_err(|error| {
+        McpError::internal_error(
+            "failed to persist changes",
+            Some(json!({ "reason": error.to_string() })),
+        )
+    })
 }
 
 pub(super) async fn create_requirement_kind(
@@ -269,41 +421,10 @@ pub(super) async fn create_requirement(
             })?;
     }
 
-    directory.flush().map_err(|error| {
-        McpError::internal_error(
-            "failed to persist requirement",
-            Some(json!({ "reason": error.to_string() })),
-        )
-    })?;
+    flush(&mut directory)?;
 
     let hrid = requirement.hrid().clone();
-    let Some(view) = directory.find_by_hrid(&hrid) else {
-        return Err(McpError::internal_error(
-            "created requirement could not be reloaded",
-            Some(json!({ "hrid": ReqMcpServer::format_hrid(&hrid, digits) })),
-        ));
-    };
-
-    let parents: Vec<String> = view
-        .parents
-        .iter()
-        .map(|(_, parent)| ReqMcpServer::format_hrid(&parent.hrid, digits))
-        .collect();
-
-    let children: Vec<String> = directory
-        .children_of(&hrid)
-        .iter()
-        .map(|child| ReqMcpServer::format_hrid(child, digits))
-        .collect();
-
-    let response = RequirementDetails {
-        hrid: ReqMcpServer::format_hrid(&hrid, digits),
-        title: view.title.to_string(),
-        body: view.body.to_string(),
-        tags: view.tags.iter().cloned().collect(),
-        parents,
-        children,
-    };
+    let response = requirement_details(&directory, &hrid, digits)?;
 
     drop(directory);
 
@@ -311,6 +432,285 @@ pub(super) async fn create_requirement(
     Ok(ReqMcpServer::success(
         summary,
         ReqMcpServer::serialize(response, "create_requirement response")?,
+    ))
+}
+
+pub(super) async fn update_requirement(
+    server: &ReqMcpServer,
+    params: Parameters<UpdateRequirementParams>,
+) -> Result<CallToolResult, McpError> {
+    let params = params.0;
+
+    if params.title.is_none() && params.body.is_none() && params.tags.is_none() {
+        return Err(McpError::invalid_params(
+            "at least one of `title`, `body`, or `tags` is required",
+            Some(json!({ "fields": ["title", "body", "tags"] })),
+        ));
+    }
+
+    let hrid = ReqMcpServer::parse_hrid(&params.hrid)?;
+    let tags: Option<BTreeSet<String>> = params
+        .tags
+        .map(|tags| tags.into_iter().map(|tag| tag.trim().to_string()).collect());
+
+    let mut directory = server.state.directory.write().await;
+    let digits = directory.config().digits();
+
+    if directory.find_by_hrid(&hrid).is_none() {
+        return Err(McpError::resource_not_found(
+            "requirement not found",
+            Some(json!({ "hrid": params.hrid })),
+        ));
+    }
+
+    let changed = directory
+        .update_requirement(&hrid, params.title, params.body, tags)
+        .map_err(|error| {
+            McpError::internal_error(
+                "failed to update requirement",
+                Some(json!({ "reason": error.to_string() })),
+            )
+        })?;
+
+    if changed {
+        flush(&mut directory)?;
+    }
+
+    let response = UpdateRequirementResponse {
+        changed,
+        requirement: requirement_details(&directory, &hrid, digits)?,
+    };
+
+    drop(directory);
+
+    let summary = if changed {
+        format!(
+            "Updated requirement {}; links from its children may now be suspect (see review)",
+            response.requirement.hrid
+        )
+    } else {
+        format!("No changes applied to {}", response.requirement.hrid)
+    };
+
+    Ok(ReqMcpServer::success(
+        summary,
+        ReqMcpServer::serialize(response, "update_requirement response")?,
+    ))
+}
+
+pub(super) async fn link_requirement(
+    server: &ReqMcpServer,
+    params: Parameters<LinkRequirementParams>,
+) -> Result<CallToolResult, McpError> {
+    let params = params.0;
+    let child = ReqMcpServer::parse_hrid(&params.child)?;
+    let parent = ReqMcpServer::parse_hrid(&params.parent)?;
+
+    let mut directory = server.state.directory.write().await;
+    let digits = directory.config().digits();
+
+    let already_linked = directory.children_of(&parent).contains(&child);
+
+    directory
+        .link_requirement(&child, &parent)
+        .map_err(|error| match error {
+            LinkRequirementError::ChildNotFound(_) => McpError::resource_not_found(
+                "child requirement not found",
+                Some(json!({ "child": ReqMcpServer::format_hrid(&child, digits) })),
+            ),
+            LinkRequirementError::ParentNotFound(_) => McpError::resource_not_found(
+                "parent requirement not found",
+                Some(json!({ "parent": ReqMcpServer::format_hrid(&parent, digits) })),
+            ),
+            LinkRequirementError::WouldCreateCycle(message) => McpError::invalid_params(
+                "cannot create link: would form a cycle",
+                Some(json!({ "reason": message })),
+            ),
+        })?;
+
+    flush(&mut directory)?;
+
+    let response = LinkRequirementResponse {
+        child: ReqMcpServer::format_hrid(&child, digits),
+        parent: ReqMcpServer::format_hrid(&parent, digits),
+        already_linked,
+    };
+
+    drop(directory);
+
+    let summary = if already_linked {
+        format!(
+            "{} was already linked to {}; refreshed the stored parent fingerprint",
+            response.child, response.parent
+        )
+    } else {
+        format!("Linked {} to parent {}", response.child, response.parent)
+    };
+
+    Ok(ReqMcpServer::success(
+        summary,
+        ReqMcpServer::serialize(response, "link_requirement response")?,
+    ))
+}
+
+pub(super) async fn unlink_requirement(
+    server: &ReqMcpServer,
+    params: Parameters<UnlinkRequirementParams>,
+) -> Result<CallToolResult, McpError> {
+    let params = params.0;
+    let child = ReqMcpServer::parse_hrid(&params.child)?;
+    let parent = ReqMcpServer::parse_hrid(&params.parent)?;
+
+    let mut directory = server.state.directory.write().await;
+    let digits = directory.config().digits();
+
+    if directory.find_by_hrid(&child).is_none() {
+        return Err(McpError::resource_not_found(
+            "child requirement not found",
+            Some(json!({ "child": ReqMcpServer::format_hrid(&child, digits) })),
+        ));
+    }
+    if directory.find_by_hrid(&parent).is_none() {
+        return Err(McpError::resource_not_found(
+            "parent requirement not found",
+            Some(json!({ "parent": ReqMcpServer::format_hrid(&parent, digits) })),
+        ));
+    }
+
+    directory
+        .unlink_requirement(&child, &parent)
+        .map_err(|error| {
+            McpError::invalid_params(
+                "link between child and parent does not exist",
+                Some(json!({
+                    "child": ReqMcpServer::format_hrid(&child, digits),
+                    "parent": ReqMcpServer::format_hrid(&parent, digits),
+                    "reason": error.to_string()
+                })),
+            )
+        })?;
+
+    flush(&mut directory)?;
+
+    let response = UnlinkRequirementResponse {
+        child: ReqMcpServer::format_hrid(&child, digits),
+        parent: ReqMcpServer::format_hrid(&parent, digits),
+    };
+
+    drop(directory);
+
+    let summary = format!(
+        "Unlinked {} from parent {}",
+        response.child, response.parent
+    );
+    Ok(ReqMcpServer::success(
+        summary,
+        ReqMcpServer::serialize(response, "unlink_requirement response")?,
+    ))
+}
+
+pub(super) async fn delete_requirement(
+    server: &ReqMcpServer,
+    params: Parameters<DeleteRequirementParams>,
+) -> Result<CallToolResult, McpError> {
+    let params = params.0;
+    let hrid = ReqMcpServer::parse_hrid(&params.hrid)?;
+
+    let mut directory = server.state.directory.write().await;
+    let digits = directory.config().digits();
+
+    if directory.find_by_hrid(&hrid).is_none() {
+        return Err(McpError::resource_not_found(
+            "requirement not found",
+            Some(json!({ "hrid": params.hrid })),
+        ));
+    }
+
+    let children = directory.children_of(&hrid);
+
+    if params.mode == DeleteMode::Refuse && !children.is_empty() {
+        return Err(McpError::invalid_params(
+            "requirement has children; use mode `orphan` to keep them or `cascade` to also \
+             delete orphaned descendants",
+            Some(json!({
+                "hrid": ReqMcpServer::format_hrid(&hrid, digits),
+                "children": children
+                    .iter()
+                    .map(|child| ReqMcpServer::format_hrid(child, digits))
+                    .collect::<Vec<_>>()
+            })),
+        ));
+    }
+
+    // What the delete will remove: just this requirement, or (for cascade)
+    // this requirement plus every descendant left without a parent.
+    let deleted = if params.mode == DeleteMode::Cascade {
+        directory.find_orphaned_descendants(&hrid)
+    } else {
+        vec![hrid.clone()]
+    };
+
+    // Children that survive the delete but lose a parent link.
+    let unlinked_children: Vec<String> = match params.mode {
+        DeleteMode::Refuse => Vec::new(),
+        DeleteMode::Orphan => children
+            .iter()
+            .map(|child| ReqMcpServer::format_hrid(child, digits))
+            .collect(),
+        DeleteMode::Cascade => {
+            let deleted_set: BTreeSet<&requiem_core::Hrid> = deleted.iter().collect();
+            let survivors: BTreeSet<String> = deleted
+                .iter()
+                .flat_map(|hrid| directory.children_of(hrid))
+                .filter(|child| !deleted_set.contains(child))
+                .map(|child| ReqMcpServer::format_hrid(&child, digits))
+                .collect();
+            survivors.into_iter().collect()
+        }
+    };
+
+    if !params.dry_run {
+        let result = match params.mode {
+            DeleteMode::Refuse => directory.delete_requirement(&hrid),
+            DeleteMode::Orphan => directory.delete_and_orphan(&hrid),
+            // Deleting via `delete_and_orphan` is order-independent: edges to
+            // already-removed members are gone, and surviving children are
+            // unlinked as their deleted parents go.
+            DeleteMode::Cascade => deleted
+                .iter()
+                .try_for_each(|hrid| directory.delete_and_orphan(hrid)),
+        };
+        result.map_err(|error| {
+            McpError::internal_error(
+                "failed to delete requirement",
+                Some(json!({ "reason": error.to_string() })),
+            )
+        })?;
+
+        flush(&mut directory)?;
+    }
+
+    let response = DeleteRequirementResponse {
+        mode: params.mode,
+        dry_run: params.dry_run,
+        deleted: deleted
+            .iter()
+            .map(|hrid| ReqMcpServer::format_hrid(hrid, digits))
+            .collect(),
+        unlinked_children,
+    };
+
+    drop(directory);
+
+    let summary = if params.dry_run {
+        format!("Would delete {} requirement(s)", response.deleted.len())
+    } else {
+        format!("Deleted {} requirement(s)", response.deleted.len())
+    };
+
+    Ok(ReqMcpServer::success(
+        summary,
+        ReqMcpServer::serialize(response, "delete_requirement response")?,
     ))
 }
 
@@ -353,12 +753,7 @@ pub(super) async fn review_requirement(
             ),
         })?;
 
-    directory.flush().map_err(|error| {
-        McpError::internal_error(
-            "failed to persist review update",
-            Some(json!({ "reason": error.to_string() })),
-        )
-    })?;
+    flush(&mut directory)?;
 
     let status = match result {
         requiem_core::storage::directory::AcceptResult::Updated => "updated",
@@ -378,4 +773,244 @@ pub(super) async fn review_requirement(
         "Suspect link marked as reviewed",
         ReqMcpServer::serialize(response, "review_requirement response")?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+    use crate::state::ServerState;
+
+    fn server_with_root() -> (tempfile::TempDir, ReqMcpServer) {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = ServerState::new(tmp.path()).unwrap();
+        (tmp, ReqMcpServer::new(state))
+    }
+
+    fn structured(result: &CallToolResult) -> Value {
+        result
+            .structured_content
+            .clone()
+            .expect("tool result should carry structured content")
+    }
+
+    async fn create(
+        server: &ReqMcpServer,
+        kind: &str,
+        title: &str,
+        parents: Vec<String>,
+    ) -> String {
+        let result = create_requirement(
+            server,
+            Parameters(CreateRequirementParams {
+                namespace: vec![],
+                kind: kind.to_string(),
+                title: title.to_string(),
+                body: "Body".to_string(),
+                parents,
+            }),
+        )
+        .await
+        .expect("create_requirement should succeed");
+        structured(&result)["hrid"].as_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn update_requirement_edits_content_in_place() {
+        let (tmp, server) = server_with_root();
+        let hrid = create(&server, "REQ", "Old title", vec![]).await;
+
+        let result = update_requirement(
+            &server,
+            Parameters(UpdateRequirementParams {
+                hrid: hrid.clone(),
+                title: Some("New title".to_string()),
+                body: Some("New body".to_string()),
+                tags: Some(vec!["safety".to_string()]),
+            }),
+        )
+        .await
+        .expect("update should succeed");
+
+        let data = structured(&result);
+        assert_eq!(data["changed"], Value::Bool(true));
+        assert_eq!(data["requirement"]["title"], "New title");
+        assert_eq!(data["requirement"]["body"], "New body");
+        assert_eq!(data["requirement"]["tags"][0], "safety");
+
+        // The change is persisted to disk.
+        let on_disk = std::fs::read_to_string(tmp.path().join(format!("{hrid}.md"))).unwrap();
+        assert!(on_disk.contains("New body"));
+
+        // Repeating the same update reports no change.
+        let result = update_requirement(
+            &server,
+            Parameters(UpdateRequirementParams {
+                hrid,
+                title: Some("New title".to_string()),
+                body: Some("New body".to_string()),
+                tags: Some(vec!["safety".to_string()]),
+            }),
+        )
+        .await
+        .expect("no-op update should succeed");
+        assert_eq!(structured(&result)["changed"], Value::Bool(false));
+    }
+
+    #[tokio::test]
+    async fn update_requirement_requires_at_least_one_field() {
+        let (_tmp, server) = server_with_root();
+        let hrid = create(&server, "REQ", "Title", vec![]).await;
+
+        let result = update_requirement(
+            &server,
+            Parameters(UpdateRequirementParams {
+                hrid,
+                title: None,
+                body: None,
+                tags: None,
+            }),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn link_and_unlink_round_trip() {
+        let (_tmp, server) = server_with_root();
+        let parent = create(&server, "SYS", "Parent", vec![]).await;
+        let child = create(&server, "USR", "Child", vec![]).await;
+
+        let result = link_requirement(
+            &server,
+            Parameters(LinkRequirementParams {
+                child: child.clone(),
+                parent: parent.clone(),
+            }),
+        )
+        .await
+        .expect("link should succeed");
+        assert_eq!(structured(&result)["alreadyLinked"], Value::Bool(false));
+
+        // Relinking the same pair is reported, not an error.
+        let result = link_requirement(
+            &server,
+            Parameters(LinkRequirementParams {
+                child: child.clone(),
+                parent: parent.clone(),
+            }),
+        )
+        .await
+        .expect("relink should succeed");
+        assert_eq!(structured(&result)["alreadyLinked"], Value::Bool(true));
+
+        // Linking the parent to its own descendant is rejected as a cycle.
+        let result = link_requirement(
+            &server,
+            Parameters(LinkRequirementParams {
+                child: parent.clone(),
+                parent: child.clone(),
+            }),
+        )
+        .await;
+        assert!(result.is_err(), "cycle-forming link must be rejected");
+
+        unlink_requirement(
+            &server,
+            Parameters(UnlinkRequirementParams {
+                child: child.clone(),
+                parent: parent.clone(),
+            }),
+        )
+        .await
+        .expect("unlink should succeed");
+
+        // The link is gone, so unlinking again fails.
+        let result = unlink_requirement(
+            &server,
+            Parameters(UnlinkRequirementParams { child, parent }),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_refuses_requirement_with_children_by_default() {
+        let (_tmp, server) = server_with_root();
+        let parent = create(&server, "SYS", "Parent", vec![]).await;
+        let _child = create(&server, "USR", "Child", vec![parent.clone()]).await;
+
+        let result = delete_requirement(
+            &server,
+            Parameters(DeleteRequirementParams {
+                hrid: parent,
+                mode: DeleteMode::Refuse,
+                dry_run: false,
+            }),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_cascade_removes_orphaned_descendants() {
+        let (tmp, server) = server_with_root();
+        let parent = create(&server, "SYS", "Parent", vec![]).await;
+        let child = create(&server, "USR", "Child", vec![parent.clone()]).await;
+
+        // Dry run reports both without deleting anything.
+        let result = delete_requirement(
+            &server,
+            Parameters(DeleteRequirementParams {
+                hrid: parent.clone(),
+                mode: DeleteMode::Cascade,
+                dry_run: true,
+            }),
+        )
+        .await
+        .expect("dry run should succeed");
+        let data = structured(&result);
+        assert_eq!(data["dryRun"], Value::Bool(true));
+        assert_eq!(data["deleted"].as_array().unwrap().len(), 2);
+        assert!(tmp.path().join(format!("{parent}.md")).exists());
+
+        let result = delete_requirement(
+            &server,
+            Parameters(DeleteRequirementParams {
+                hrid: parent.clone(),
+                mode: DeleteMode::Cascade,
+                dry_run: false,
+            }),
+        )
+        .await
+        .expect("cascade delete should succeed");
+        let data = structured(&result);
+        assert_eq!(data["deleted"].as_array().unwrap().len(), 2);
+        assert!(!tmp.path().join(format!("{parent}.md")).exists());
+        assert!(!tmp.path().join(format!("{child}.md")).exists());
+    }
+
+    #[tokio::test]
+    async fn delete_orphan_keeps_children() {
+        let (tmp, server) = server_with_root();
+        let parent = create(&server, "SYS", "Parent", vec![]).await;
+        let child = create(&server, "USR", "Child", vec![parent.clone()]).await;
+
+        let result = delete_requirement(
+            &server,
+            Parameters(DeleteRequirementParams {
+                hrid: parent.clone(),
+                mode: DeleteMode::Orphan,
+                dry_run: false,
+            }),
+        )
+        .await
+        .expect("orphan delete should succeed");
+        let data = structured(&result);
+        assert_eq!(data["deleted"].as_array().unwrap().len(), 1);
+        assert_eq!(data["unlinkedChildren"][0], child.clone());
+        assert!(!tmp.path().join(format!("{parent}.md")).exists());
+        assert!(tmp.path().join(format!("{child}.md")).exists());
+    }
 }


### PR DESCRIPTION
## Summary

Assessment of the MCP server found it read-mostly: discovery, graph traversal, and the suspect-link review workflow are covered, plus creation tools — but there was no way to modify, re-link, or remove existing requirements through MCP, all of which the CLI and core library already support. This PR adds the three most important missing features:

1. **`update_requirement`** — edit the title, body, and/or tags of an existing requirement in place (was explicitly listed as "planned" in the req-mcp README). Omitted fields are left unchanged; no-op updates are reported via a `changed` flag. Identity (UUID/HRID) and links are untouched, and body/tag changes flow through the existing fingerprint → suspect-link → review workflow.
2. **`link_requirement` / `unlink_requirement`** — manage parent-child traceability links between *existing* requirements (previously links could only be set at creation time). Cycle-forming links are rejected with a structured error, and relinking an existing pair is reported via `alreadyLinked` (it refreshes the stored parent fingerprint, equivalent to accepting a suspect link).
3. **`delete_requirement`** — remove requirements with the same safety rails as `req delete`: a `mode` parameter (`refuse` [default] / `orphan` / `cascade`) controls children handling, and `dryRun` previews exactly which HRIDs would be deleted and which children would be unlinked, without changing anything.

## Implementation notes

- `update_requirement` needed a small core addition: `Tree::update_requirement_content` and `Directory::update_requirement` (the core previously had no content-update API at all — edits were only possible by hand-editing markdown files).
- Cascade delete uses `delete_and_orphan` per member of the orphaned-descendant set, which is order-independent (looping `delete_requirement` over the HRID-sorted set can hit the has-children guard when a parent sorts before its child).
- Extracted shared `requirement_details`/`flush` helpers in the editing module and reused them in `create_requirement`.
- Server instructions and the README tool list are updated; "in-place requirement updates" is removed from the planned list.

## Testing

- 5 new core tests covering content updates, persistence, no-op detection, suspect-link propagation, and missing-HRID errors.
- 6 new MCP-level tests exercising the tool handlers end-to-end against a temp directory: update (including persistence to disk and no-op), link/relink/cycle-rejection/unlink, and delete in refuse/orphan/cascade modes with dry-run.
- `cargo clippy --workspace --all-targets` clean; full workspace test suite passes (the only 2 failures are pre-existing permission-based tests that fail when run as root).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZadQ5BGenVxSoc1GkrvWP)_